### PR TITLE
Travis CI cross architecture Docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - docker buildx create --name xbuilder --use
 script: bash ci.sh
 after_success:
-  - curl -X POST https://hooks.microbadger.com/images/$DOCKER_REPO/tQFy7AxtSUNANPe6aoVChYdsI_I= || exit 0
+  - curl -X POST https://hooks.microbadger.com/images/$DOCKER_REPO/t2fcZxog8ce_kJYJ61JjkYwHF5s= || exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
-language: go
-go:
-  - 1.13.x
-env:
-  - GO111MODULE=on
+dist: xenial
+sudo: required
 git:
+  quiet: true
   depth: 1
-intall: go mod download
-script: go test -v -race ./...
+env:
+  global:
+    - DOCKER_REPO=qmcgaw/ddns-updater
+before_install:
+  - curl -fsSL https://get.docker.com | sh
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - mkdir -p $HOME/.docker
+  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  - sudo service docker start
+install:
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --name xbuilder --use
+script: bash ci.sh
+after_success:
+  - curl -X POST https://hooks.microbadger.com/images/$DOCKER_REPO/tQFy7AxtSUNANPe6aoVChYdsI_I= || exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_install:
 install:
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   - docker buildx create --name xbuilder --use
-script: bash ci.sh
+script: travis_wait 60 bash ci.sh
 after_success:
   - curl -X POST https://hooks.microbadger.com/images/$DOCKER_REPO/t2fcZxog8ce_kJYJ61JjkYwHF5s= || exit 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 ARG ALPINE_VERSION=3.10
 ARG GO_VERSION=1.13
 
+<<<<<<< HEAD
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
+=======
+FROM golang:${GO_VERSION}-buster AS builder
+>>>>>>> Travis CI cross architecture Docker builds
 RUN apk --update add git g++
 WORKDIR /tmp/gobuild
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=3.10
 ARG GO_VERSION=1.13
 
-FROM golang:${GO_VERSION}-buster AS builder
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 RUN apk --update add git g++
 WORKDIR /tmp/gobuild
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,30 @@
-ARG BASE_IMAGE_BUILDER=golang
-ARG BASE_IMAGE=alpine
 ARG ALPINE_VERSION=3.10
 ARG GO_VERSION=1.13
 
-FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
-ARG GOARCH=amd64
-ARG GOARM=
-RUN apk --update add git build-base
+FROM golang:${GO_VERSION}-buster AS builder
+RUN apk --update add git g++
 WORKDIR /tmp/gobuild
 COPY go.mod go.sum ./
 RUN go mod download 2>&1
 COPY internal/ ./internal/
 COPY cmd/updater/main.go .
 #RUN go test -v ./...
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -installsuffix cgo -ldflags="-s -w" -o app
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -ldflags="-s -w" -o app
 
-FROM ${BASE_IMAGE}:${ALPINE_VERSION} AS final
+FROM alpine:${ALPINE_VERSION}
 ARG BUILD_DATE
 ARG VCS_REF
+ARG VERSION
 LABEL \
     org.opencontainers.image.authors="quentin.mcgaw@gmail.com" \
     org.opencontainers.image.created=$BUILD_DATE \
-    org.opencontainers.image.version="" \
+    org.opencontainers.image.version=$VERSION \
     org.opencontainers.image.revision=$VCS_REF \
     org.opencontainers.image.url="https://github.com/qdm12/ddns-updater" \
     org.opencontainers.image.documentation="https://github.com/qdm12/ddns-updater" \
     org.opencontainers.image.source="https://github.com/qdm12/ddns-updater" \
     org.opencontainers.image.title="ddns-updater" \
-    org.opencontainers.image.description="Universal DNS updater with WebUI. Works with Namecheap, Cloudflare, GoDaddy, DuckDns, Dreamhost and NoIP" \
-    image-size="22.2MB" \
-    ram-usage="13MB" \
-    cpu-usage="Very Low"
+    org.opencontainers.image.description="Universal DNS updater with WebUI. Works with Namecheap, Cloudflare, GoDaddy, DuckDns, Dreamhost and NoIP"
 RUN apk add --update sqlite ca-certificates && \
     mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
     rm -rf /var/cache/apk/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 ARG ALPINE_VERSION=3.10
 ARG GO_VERSION=1.13
 
-<<<<<<< HEAD
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
-=======
-FROM golang:${GO_VERSION}-buster AS builder
->>>>>>> Travis CI cross architecture Docker builds
 RUN apk --update add git g++
 WORKDIR /tmp/gobuild
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - Docker healthcheck verifying the DNS resolution of your domains
 - Highly configurable
 - Sends notifications to your Android phone, see the [**Gotify**](#Gotify) section (it's free, open source and self hosted 🆒)
-- Compatible with `amd64` and `386` for now, see below for `arm` and other architectures.
+- Compatible with `amd64`, `386`, `arm64` and `arm32v7` (Raspberry Pis) CPU architectures.
 
 ## Setup
 
@@ -81,18 +81,6 @@
     ```
 
     See more information at the [configuration section](#configuration)
-
-1. <details><summary>CLICK IF YOU HAVE AN ARM OR NON-AMD64/386 DEVICE</summary><p>
-
-    For now, ARM Docker images cannot be built automatically and pushed to Docker Hub with a manifest.
-
-    The alternative for now is to build the image on your device:
-
-    ```sh
-    docker build -t qmcgaw/ddns-updater https://github.com/qdm12/ddns-updater.git
-    ```
-
-    </p></details>
 
 1. Use the following command:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - Docker healthcheck verifying the DNS resolution of your domains
 - Highly configurable
 - Sends notifications to your Android phone, see the [**Gotify**](#Gotify) section (it's free, open source and self hosted 🆒)
-- Compatible with all CPU architectures Docker supports (ARM, s390x, etc.)
+- Compatible with `amd64` and `386` for now, see below for `arm` and other architectures.
 
 ## Setup
 
@@ -81,6 +81,18 @@
     ```
 
     See more information at the [configuration section](#configuration)
+
+1. <details><summary>CLICK IF YOU HAVE AN ARM OR NON-AMD64/386 DEVICE</summary><p>
+
+    For now, ARM Docker images cannot be built automatically and pushed to Docker Hub with a manifest.
+
+    The alternative for now is to build the image on your device:
+
+    ```sh
+    docker build -t qmcgaw/ddns-updater https://github.com/qdm12/ddns-updater.git
+    ```
+
+    </p></details>
 
 1. Use the following command:
 
@@ -178,25 +190,11 @@ Please then refer to your specific DNS host provider in the section below for ev
 | `DELAY` | `300` | Delay between updates in seconds |
 | `ROOT_URL` | `/` | URL path to append to all paths to the webUI (i.e. `/ddns` for accessing `https://example.com/ddns` through a proxy) |
 | `LISTENING_PORT` | `8000` | Internal TCP listening port for the web UI |
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Removed old docker build hooks
 | `LOG_ENCODING` | `json` | Format of logging, `json` or `human` |
 | `LOG_LEVEL` | `info` | Level of logging, `info`, ~`success`~, `warning` or `error` |
 | `NODE_ID` | `0` | Node ID (for distributed systems), can be any integer |
 | `GOTIFY_URL` |  | HTTP(s) URL to your Gotify server |
 | `GOTIFY_TOKEN` |  | Token to access your Gotify server |
-<<<<<<< HEAD
-=======
-| `LOG_ENCODING_` | `console` | Format of logging, `json` or `console` |
-| `LOG_LEVEL` | `info` | Level of logging, `info`, `warning` or `error` |
-| `NODEID` | `0` | Node ID (for distributed systems), can be any integer |
-| `GOTIFY_URL` |  | Optional HTTP(s) URL to your Gotify server |
-| `GOTIFY_TOKEN` |  | Optional token to access your Gotify server |
->>>>>>> Full refactor using qdm12/golibs (#22)
-=======
->>>>>>> Removed old docker build hooks
 
 ### Host firewall
 

--- a/README.md
+++ b/README.md
@@ -179,11 +179,15 @@ Please then refer to your specific DNS host provider in the section below for ev
 | `ROOT_URL` | `/` | URL path to append to all paths to the webUI (i.e. `/ddns` for accessing `https://example.com/ddns` through a proxy) |
 | `LISTENING_PORT` | `8000` | Internal TCP listening port for the web UI |
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Removed old docker build hooks
 | `LOG_ENCODING` | `json` | Format of logging, `json` or `human` |
 | `LOG_LEVEL` | `info` | Level of logging, `info`, ~`success`~, `warning` or `error` |
 | `NODE_ID` | `0` | Node ID (for distributed systems), can be any integer |
 | `GOTIFY_URL` |  | HTTP(s) URL to your Gotify server |
 | `GOTIFY_TOKEN` |  | Token to access your Gotify server |
+<<<<<<< HEAD
 =======
 | `LOG_ENCODING_` | `console` | Format of logging, `json` or `console` |
 | `LOG_LEVEL` | `info` | Level of logging, `info`, `warning` or `error` |
@@ -191,6 +195,8 @@ Please then refer to your specific DNS host provider in the section below for ev
 | `GOTIFY_URL` |  | Optional HTTP(s) URL to your Gotify server |
 | `GOTIFY_TOKEN` |  | Optional token to access your Gotify server |
 >>>>>>> Full refactor using qdm12/golibs (#22)
+=======
+>>>>>>> Removed old docker build hooks
 
 ### Host firewall
 

--- a/README.md
+++ b/README.md
@@ -6,24 +6,16 @@
 
 [![DDNS Updater by Quentin McGaw](https://github.com/qdm12/ddns-updater/raw/master/readme/title.png)](https://hub.docker.com/r/qmcgaw/ddns-updater)
 
-[![Join Slack channel](https://img.shields.io/badge/slack-@qdm12-yellow.svg?logo=slack)](https://join.slack.com/t/qdm12/shared_invite/enQtODMwMDQyMTAxMjY1LTU1YjE1MTVhNTBmNTViNzJiZmQwZWRmMDhhZjEyNjVhZGM4YmIxOTMxOTYzN2U0N2U2YjQ2MDk3YmYxN2NiNTc)
 [![Build Status](https://travis-ci.org/qdm12/ddns-updater.svg?branch=master)](https://travis-ci.org/qdm12/ddns-updater)
-[![Docker Build Status](https://img.shields.io/docker/build/qmcgaw/ddns-updater.svg)](https://hub.docker.com/r/qmcgaw/ddns-updater)
-
-[![GitHub last commit](https://img.shields.io/github/last-commit/qdm12/ddns-updater.svg)](https://github.com/qdm12/ddns-updater/issues)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/qdm12/ddns-updater.svg)](https://github.com/qdm12/ddns-updater/issues)
-[![GitHub issues](https://img.shields.io/github/issues/qdm12/ddns-updater.svg)](https://github.com/qdm12/ddns-updater/issues)
-
 [![Docker Pulls](https://img.shields.io/docker/pulls/qmcgaw/ddns-updater.svg)](https://hub.docker.com/r/qmcgaw/ddns-updater)
 [![Docker Stars](https://img.shields.io/docker/stars/qmcgaw/ddns-updater.svg)](https://hub.docker.com/r/qmcgaw/ddns-updater)
-[![Docker Automated](https://img.shields.io/docker/automated/qmcgaw/ddns-updater.svg)](https://hub.docker.com/r/qmcgaw/ddns-updater)
-
 [![Image size](https://images.microbadger.com/badges/image/qmcgaw/ddns-updater.svg)](https://microbadger.com/images/qmcgaw/ddns-updater)
 [![Image version](https://images.microbadger.com/badges/version/qmcgaw/ddns-updater.svg)](https://microbadger.com/images/qmcgaw/ddns-updater)
 
-| Image size | RAM usage | CPU usage |
-| --- | --- | --- |
-| 22.2MB | 13MB | Very low |
+[![Join Slack channel](https://img.shields.io/badge/slack-@qdm12-yellow.svg?logo=slack)](https://join.slack.com/t/qdm12/shared_invite/enQtODMwMDQyMTAxMjY1LTU1YjE1MTVhNTBmNTViNzJiZmQwZWRmMDhhZjEyNjVhZGM4YmIxOTMxOTYzN2U0N2U2YjQ2MDk3YmYxN2NiNTc)
+[![GitHub last commit](https://img.shields.io/github/last-commit/qdm12/ddns-updater.svg)](https://github.com/qdm12/ddns-updater/issues)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/qdm12/ddns-updater.svg)](https://github.com/qdm12/ddns-updater/issues)
+[![GitHub issues](https://img.shields.io/github/issues/qdm12/ddns-updater.svg)](https://github.com/qdm12/ddns-updater/issues)
 
 ## Features
 
@@ -32,11 +24,12 @@
 
 ![Web UI](https://raw.githubusercontent.com/qdm12/ddns-updater/master/readme/webui.png)
 
-- Lightweight based on Go and *Alpine 3.10* with Sqlite and Ca-Certificates packages
+- Lightweight based on a Go binary and *Alpine 3.10* with Sqlite and Ca-Certificates packages
 - Persistence with a sqlite database to store old IP addresses and previous update status
 - Docker healthcheck verifying the DNS resolution of your domains
 - Highly configurable
 - Sends notifications to your Android phone, see the [**Gotify**](#Gotify) section (it's free, open source and self hosted 🆒)
+- Compatible with all CPU architectures Docker supports (ARM, s390x, etc.)
 
 ## Setup
 
@@ -88,42 +81,6 @@
     ```
 
     See more information at the [configuration section](#configuration)
-
-1. <details><summary>CLICK IF YOU HAVE AN ARM DEVICE</summary><p>
-
-    - If you have a ARM 32 bit v6 architecture
-
-        ```sh
-        docker build -t qmcgaw/ddns-updater \
-        --build-arg BASE_IMAGE_BUILDER=arm32v6/golang \
-        --build-arg BASE_IMAGE=arm32v6/alpine \
-        --build-arg GOARCH=arm \
-        --build-arg GOARM=6 \
-        https://github.com/qdm12/ddns-updater.git
-        ```
-
-    - If you have a ARM 32 bit v7 architecture
-
-        ```sh
-        docker build -t qmcgaw/ddns-updater \
-        --build-arg BASE_IMAGE_BUILDER=arm32v7/golang \
-        --build-arg BASE_IMAGE=arm32v7/alpine \
-        --build-arg GOARCH=arm \
-        --build-arg GOARM=7 \
-        https://github.com/qdm12/ddns-updater.git
-        ```
-
-    - If you have a ARM 64 bit v8 architecture
-
-        ```sh
-        docker build -t qmcgaw/ddns-updater \
-        --build-arg BASE_IMAGE_BUILDER=arm64v8/golang \
-        --build-arg BASE_IMAGE=arm64v8/alpine \
-        --build-arg GOARCH=arm64 \
-        https://github.com/qdm12/ddns-updater.git
-        ```
-
-    </p></details>
 
 1. Use the following command:
 

--- a/README.md
+++ b/README.md
@@ -178,11 +178,19 @@ Please then refer to your specific DNS host provider in the section below for ev
 | `DELAY` | `300` | Delay between updates in seconds |
 | `ROOT_URL` | `/` | URL path to append to all paths to the webUI (i.e. `/ddns` for accessing `https://example.com/ddns` through a proxy) |
 | `LISTENING_PORT` | `8000` | Internal TCP listening port for the web UI |
+<<<<<<< HEAD
 | `LOG_ENCODING` | `json` | Format of logging, `json` or `human` |
 | `LOG_LEVEL` | `info` | Level of logging, `info`, ~`success`~, `warning` or `error` |
 | `NODE_ID` | `0` | Node ID (for distributed systems), can be any integer |
 | `GOTIFY_URL` |  | HTTP(s) URL to your Gotify server |
 | `GOTIFY_TOKEN` |  | Token to access your Gotify server |
+=======
+| `LOG_ENCODING_` | `console` | Format of logging, `json` or `console` |
+| `LOG_LEVEL` | `info` | Level of logging, `info`, `warning` or `error` |
+| `NODEID` | `0` | Node ID (for distributed systems), can be any integer |
+| `GOTIFY_URL` |  | Optional HTTP(s) URL to your Gotify server |
+| `GOTIFY_TOKEN` |  | Optional token to access your Gotify server |
+>>>>>>> Full refactor using qdm12/golibs (#22)
 
 ### Host firewall
 

--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ Please then refer to your specific DNS host provider in the section below for ev
 | `DELAY` | `300` | Delay between updates in seconds |
 | `ROOT_URL` | `/` | URL path to append to all paths to the webUI (i.e. `/ddns` for accessing `https://example.com/ddns` through a proxy) |
 | `LISTENING_PORT` | `8000` | Internal TCP listening port for the web UI |
-| `LOG_ENCODING_` | `console` | Format of logging, `json` or `console` |
-| `LOG_LEVEL` | `info` | Level of logging, `info`, `warning` or `error` |
-| `NODEID` | `0` | Node ID (for distributed systems), can be any integer |
-| `GOTIFY_URL` |  | Optional HTTP(s) URL to your Gotify server |
-| `GOTIFY_TOKEN` |  | Optional token to access your Gotify server |
+| `LOG_ENCODING` | `json` | Format of logging, `json` or `human` |
+| `LOG_LEVEL` | `info` | Level of logging, `info`, ~`success`~, `warning` or `error` |
+| `NODE_ID` | `0` | Node ID (for distributed systems), can be any integer |
+| `GOTIFY_URL` |  | HTTP(s) URL to your Gotify server |
+| `GOTIFY_TOKEN` |  | Token to access your Gotify server |
 
 ### Host firewall
 
@@ -333,4 +333,3 @@ To set it up with DDNS updater:
 - [ ] ReactJS frontend
     - [ ] Live update of website
     - [ ] Change settings
-    - [ ] Events log

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
+  docker buildx build --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x  .
+  return $?
+fi
+echo $DOCKER_PASSWORD | docker login -u qmcgaw --password-stdin &> /dev/null
+TAG="$TRAVIS_BRANCH"
+if [ "$TAG" = "master" ]; then
+  TAG="${TRAVIS_TAG:-latest}"
+fi
+echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
+docker buildx build \
+    --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x \
+    --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg VERSION=$TAG \
+    -t $DOCKER_REPO:$TAG \
+    --push \
+    .

--- a/ci.sh
+++ b/ci.sh
@@ -11,7 +11,7 @@ if [ "$TAG" = "master" ]; then
 fi
 echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
 docker buildx build \
-    --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x \
+    --platform=linux/amd64 \
     --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
     --build-arg VCS_REF=`git rev-parse --short HEAD` \
     --build-arg VERSION=$TAG \

--- a/ci.sh
+++ b/ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
-  docker buildx build --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x  .
+  docker buildx build --platform=linux/amd64,linux/386 .
   return $?
 fi
 echo $DOCKER_PASSWORD | docker login -u qmcgaw --password-stdin &> /dev/null
@@ -11,7 +11,7 @@ if [ "$TAG" = "master" ]; then
 fi
 echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
 docker buildx build \
-    --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x \
+    --platform=linux/amd64,linux/386 \
     --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
     --build-arg VCS_REF=`git rev-parse --short HEAD` \
     --build-arg VERSION=$TAG \

--- a/ci.sh
+++ b/ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
-  docker buildx build --platform=linux/amd64,linux/386 .
+  docker buildx build --platform=linux/amd64,linux/386 --progress plain .
   return $?
 fi
 echo $DOCKER_PASSWORD | docker login -u qmcgaw --password-stdin &> /dev/null
@@ -12,6 +12,7 @@ fi
 echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
 docker buildx build \
     --platform=linux/amd64,linux/386 \
+    --progress plain \
     --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
     --build-arg VCS_REF=`git rev-parse --short HEAD` \
     --build-arg VERSION=$TAG \

--- a/ci.sh
+++ b/ci.sh
@@ -11,11 +11,7 @@ if [ "$TAG" = "master" ]; then
 fi
 echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
 docker buildx build \
-<<<<<<< HEAD
-    --platform=linux/amd64 \
-=======
     --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x \
->>>>>>> Travis CI cross architecture Docker builds
     --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
     --build-arg VCS_REF=`git rev-parse --short HEAD` \
     --build-arg VERSION=$TAG \

--- a/ci.sh
+++ b/ci.sh
@@ -11,7 +11,11 @@ if [ "$TAG" = "master" ]; then
 fi
 echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
 docker buildx build \
+<<<<<<< HEAD
     --platform=linux/amd64 \
+=======
+    --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x \
+>>>>>>> Travis CI cross architecture Docker builds
     --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
     --build-arg VCS_REF=`git rev-parse --short HEAD` \
     --build-arg VERSION=$TAG \

--- a/ci.sh
+++ b/ci.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
-  docker buildx build --platform=linux/amd64,linux/386 --progress plain .
+if [ "$TRAVIS_PULL_REQUEST" = "true" ] || [ "$TRAVIS_BRANCH" != "master" ]; then
+  docker buildx build \
+      --progress plain \
+      --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7 \
+      .
   return $?
 fi
 echo $DOCKER_PASSWORD | docker login -u qmcgaw --password-stdin &> /dev/null
-TAG="$TRAVIS_BRANCH"
-if [ "$TAG" = "master" ]; then
-  TAG="${TRAVIS_TAG:-latest}"
-fi
+TAG="${TRAVIS_TAG:-latest}"
 echo "Building Docker images for \"$DOCKER_REPO:$TAG\""
 docker buildx build \
-    --platform=linux/amd64,linux/386 \
     --progress plain \
+    --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7 \
     --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
     --build-arg VCS_REF=`git rev-parse --short HEAD` \
     --build-arg VERSION=$TAG \

--- a/ci.sh
+++ b/ci.sh
@@ -5,7 +5,7 @@ if [ "$TRAVIS_PULL_REQUEST" = "true" ] || [ "$TRAVIS_BRANCH" != "master" ]; then
       --progress plain \
       --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v7 \
       .
-  return $?
+  exit $?
 fi
 echo $DOCKER_PASSWORD | docker login -u qmcgaw --password-stdin &> /dev/null
 TAG="${TRAVIS_TAG:-latest}"

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-             --build-arg VCS_REF=`git rev-parse --short HEAD` \
-             -t $IMAGE_NAME .

--- a/hooks/post_build
+++ b/hooks/post_build
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-curl -X POST https://hooks.microbadger.com/images/qmcgaw/ddns-updater/t2fcZxog8ce_kJYJ61JjkYwHF5s= || exit 0


### PR DESCRIPTION
- Builds Docker images for all ARM CPU Architectures, s390x amd64, x86 and ppc64le
- Go tests are run in the Docker build intermediate stage, using Go-1.13 buster (Alpine cannot run `-race` for now)
- Updated readme