### PR TITLE
Document ttl parameter for cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Please then refer to your specific DNS host provider in the section below for ev
     - `"zone_identifier"`
     - `"identifier"`
     - `"host"` is your host and can be a subdomain, `@` or `*` generally
+    - `"ttl"` integer value for record TTL (specify 1 for automatic)
     - Either:
         - Email `"email"` and Key `"key"`
         - User service key `"user_service_key"`


### PR DESCRIPTION
The ttl parameter was added for Cloudflare requests in the last commit but the docs don't mention it. Updated the README accordingly