### PR TITLE
Add support for Cloudflare API Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Please then refer to your specific DNS host provider in the section below for ev
     - Either:
         - Email `"email"` and Key `"key"`
         - User service key `"user_service_key"`
+        - API Token `"token"`, configured with DNS edit permissions for your DNS name's zone.
 - Optional:
     - `"proxied"` is a boolean to use the proxy services of Cloudflare
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -103,6 +103,7 @@ func update(
 			recordConfig.Settings.Email,
 			recordConfig.Settings.Key,
 			recordConfig.Settings.UserServiceKey,
+			recordConfig.Settings.Token,
 			ip,
 			recordConfig.Settings.Proxied,
 			recordConfig.Settings.Ttl,
@@ -259,7 +260,7 @@ func updateGoDaddy(client libnetwork.Client, host, domain, key, secret, ip strin
 	return nil
 }
 
-func updateCloudflare(client libnetwork.Client, zoneIdentifier, identifier, host, email, key, userServiceKey, ip string, proxied bool, ttl uint) (err error) {
+func updateCloudflare(client libnetwork.Client, zoneIdentifier, identifier, host, email, key, userServiceKey, token, ip string, proxied bool, ttl uint) (err error) {
 	if len(ip) == 0 {
 		return fmt.Errorf("invalid empty IP address")
 	}
@@ -284,7 +285,9 @@ func updateCloudflare(client libnetwork.Client, zoneIdentifier, identifier, host
 	if err != nil {
 		return err
 	}
-	if len(userServiceKey) > 0 {
+	if len(token) > 0 {
+		r.Header.Set("Authorization", "Bearer "+token)
+	} else if len(userServiceKey) > 0 {
 		r.Header.Set("X-Auth-User-Service-Key", userServiceKey)
 	} else if len(email) > 0 && len(key) > 0 {
 		r.Header.Set("X-Auth-Email", email)


### PR DESCRIPTION
This PR adds support for authenticating using Cloudflare API tokens, rather than
having to use your personal API key.

This is a more secure option, since the API tokens can be rolled over a lot
easier, and can be locked down to specific resources and actions.

I've tested this working on my own machine and seems to work great!

[Information about the API tokens](https://blog.cloudflare.com/api-tokens-general-availability/)

Thanks for releasing this software, it's been really handy for my home setup!