### PR TITLE
Fix bug in (*params.reader).GetIPv6Method

### DIFF
--- a/internal/params/params.go
+++ b/internal/params/params.go
@@ -178,7 +178,7 @@ func (r *reader) GetIPv6Method() (method models.IPMethod, err error) {
 	return models.IPMethod{
 		Name: s,
 		URL:  s,
-		IPv4: true,
+		IPv6: true,
 	}, nil
 }
 


### PR DESCRIPTION
I may be wrong but isn't this a bug?