### PR TITLE
Gandi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
     - Dreamhost
     - DuckDNS
     - DynDNS
+    - Gandi
     - GoDaddy
     - Google
     - He.net
@@ -135,6 +136,7 @@ Check the documentation for your DNS provider:
 - [DuckDNS](docs/duckdns.md)
 - [DynDNS](docs/dyndns.md)
 - [DynV6](docs/dynv6.md)
+- [Gandi](docs/gandi.md)
 - [GoDaddy](docs/godaddy.md)
 - [Google](docs/google.md)
 - [He.net](docs/he.net.md)

--- a/docs/gandi.md
+++ b/docs/gandi.md
@@ -12,7 +12,7 @@ This provider uses Gandi v5 API
     {
       "provider": "gandi",
       "domain": "domain.com",
-      "name": "@",
+      "host": "@",
       "key": "key",
       "ttl": 3600,
       "ip_version": "ipv4",
@@ -21,12 +21,16 @@ This provider uses Gandi v5 API
 }
 ```
 
-If no ttl is defined, default is 3600
-
 ### Compulsory parameters
 
 - `"domain"` is your fqdn, for example `subdomain.duckdns.org`
+- `"host"`
 - `"key"`
+
+### Optional parameters
+
+- `"ip_version"` can be `ipv4` (A records) or `ipv6` (AAAA records), defaults to `ipv4 or ipv6`
+- `"ttl"` default is `3600`
 
 ## Domain setup
 

--- a/docs/gandi.md
+++ b/docs/gandi.md
@@ -1,0 +1,33 @@
+# Gandi
+
+This provider uses Gandi v5 API
+
+## Configuration
+
+### Example
+
+```json
+{
+  "settings": [
+    {
+      "provider": "gandi",
+      "domain": "domain.com",
+      "name": "@",
+      "key": "key",
+      "ttl": 3600,
+      "ip_version": "ipv4",
+    }
+  ]
+}
+```
+
+If no ttl is defined, default is 3600
+
+### Compulsory parameters
+
+- `"domain"` is your fqdn, for example `subdomain.duckdns.org`
+- `"key"`
+
+## Domain setup
+
+[Gandi Documentation Website](https://docs.gandi.net/en/domain_names/advanced_users/api.html#gandi-s-api)

--- a/docs/gandi.md
+++ b/docs/gandi.md
@@ -23,7 +23,7 @@ This provider uses Gandi v5 API
 
 ### Compulsory parameters
 
-- `"domain"` is your fqdn, for example `subdomain.duckdns.org`
+- `"domain"`
 - `"host"`
 - `"key"`
 

--- a/docs/gandi.md
+++ b/docs/gandi.md
@@ -24,7 +24,7 @@ This provider uses Gandi v5 API
 ### Compulsory parameters
 
 - `"domain"`
-- `"host"`
+- `"host"` which can be a subdomain, `@` or a wildcard `*`
 - `"key"`
 
 ### Optional parameters

--- a/internal/constants/providers.go
+++ b/internal/constants/providers.go
@@ -14,6 +14,7 @@ const (
 	DYN          models.Provider = "dyn"
 	DYNV6        models.Provider = "dynv6"
 	DREAMHOST    models.Provider = "dreamhost"
+	GANDI        models.Provider = "gandi"
 	GODADDY      models.Provider = "godaddy"
 	GOOGLE       models.Provider = "google"
 	HE           models.Provider = "he"
@@ -40,6 +41,7 @@ func ProviderChoices() []models.Provider {
 		DYN,
 		DYNV6,
 		DREAMHOST,
+		GANDI,
 		GODADDY,
 		GOOGLE,
 		HE,

--- a/internal/params/json.go
+++ b/internal/params/json.go
@@ -128,6 +128,8 @@ func makeSettingsFromObject(common commonSettings, rawSettings json.RawMessage, 
 		settingsConstructor = settings.NewDreamhost
 	case constants.DUCKDNS:
 		settingsConstructor = settings.NewDuckdns
+	case constants.GANDI:
+		settingsConstructor = settings.NewGandi
 	case constants.GODADDY:
 		settingsConstructor = settings.NewGodaddy
 	case constants.GOOGLE:

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -3,6 +3,7 @@ package regex
 import "regexp"
 
 type Matcher interface {
+	GandiKey(s string) bool
 	GodaddyKey(s string) bool
 	GodaddySecret(s string) bool
 	DuckDNSToken(s string) bool
@@ -15,12 +16,16 @@ type Matcher interface {
 }
 
 type matcher struct {
-	goDaddyKey, goDaddySecret, duckDNSToken, namecheapPassword, dreamhostKey, cloudflareKey, cloudflareUserServiceKey,
-	dnsOMaticUsername, dnsOMaticPassword *regexp.Regexp
+	gandiKey, goDaddyKey, goDaddySecret, duckDNSToken, namecheapPassword, dreamhostKey, cloudflareKey,
+	cloudflareUserServiceKey, dnsOMaticUsername, dnsOMaticPassword *regexp.Regexp
 }
 
 func NewMatcher() (m Matcher, err error) {
 	matcher := &matcher{}
+	matcher.gandiKey, err = regexp.Compile(`^[A-Za-z0-9]{24}$`)
+	if err != nil {
+		return nil, err
+	}
 	matcher.goDaddyKey, err = regexp.Compile(`^[A-Za-z0-9]{8,14}\_[A-Za-z0-9]{22}$`)
 	if err != nil {
 		return nil, err
@@ -60,6 +65,7 @@ func NewMatcher() (m Matcher, err error) {
 	return matcher, nil
 }
 
+func (m *matcher) GandiKey(s string) bool          { return m.gandiKey.MatchString(s) }
 func (m *matcher) GodaddyKey(s string) bool        { return m.goDaddyKey.MatchString(s) }
 func (m *matcher) GodaddySecret(s string) bool     { return m.goDaddySecret.MatchString(s) }
 func (m *matcher) DuckDNSToken(s string) bool      { return m.duckDNSToken.MatchString(s) }

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -16,8 +16,8 @@ type Matcher interface {
 }
 
 type matcher struct {
-	gandiKey, goDaddyKey, goDaddySecret, duckDNSToken, namecheapPassword, dreamhostKey, cloudflareKey,
-	cloudflareUserServiceKey, dnsOMaticUsername, dnsOMaticPassword *regexp.Regexp
+	goDaddyKey, goDaddySecret, duckDNSToken, namecheapPassword, dreamhostKey, cloudflareKey,
+	cloudflareUserServiceKey, dnsOMaticUsername, dnsOMaticPassword, gandiKey *regexp.Regexp
 }
 
 func NewMatcher() (m Matcher, err error) {

--- a/internal/settings/errors.go
+++ b/internal/settings/errors.go
@@ -32,7 +32,6 @@ var (
 	ErrCreateRecord    = errors.New("cannot create record")
 	ErrGetDomainID     = errors.New("cannot get domain ID")
 	ErrGetRecordID     = errors.New("cannot get record ID")
-	ErrGetRecordIP     = errors.New("cannot get record IP")
 	ErrGetRecordInZone = errors.New("cannot get record in zone") // LuaDNS
 	ErrGetZoneID       = errors.New("cannot get zone ID")        // LuaDNS
 	ErrListRecords     = errors.New("cannot list records")       // Dreamhost

--- a/internal/settings/errors.go
+++ b/internal/settings/errors.go
@@ -10,6 +10,7 @@ var (
 var (
 	ErrEmptyName               = errors.New("empty name")
 	ErrEmptyPassword           = errors.New("empty password")
+	ErrEmptyKey                = errors.New("empty key")
 	ErrEmptyToken              = errors.New("empty token")
 	ErrEmptyTTL                = errors.New("TTL is not set")
 	ErrEmptyUsername           = errors.New("empty username")
@@ -31,6 +32,7 @@ var (
 	ErrCreateRecord    = errors.New("cannot create record")
 	ErrGetDomainID     = errors.New("cannot get domain ID")
 	ErrGetRecordID     = errors.New("cannot get record ID")
+	ErrGetRecordIP     = errors.New("cannot get record IP")
 	ErrGetRecordInZone = errors.New("cannot get record in zone") // LuaDNS
 	ErrGetZoneID       = errors.New("cannot get zone ID")        // LuaDNS
 	ErrListRecords     = errors.New("cannot list records")       // Dreamhost

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -25,7 +25,7 @@ type gandi struct {
 }
 
 func NewGandi(data json.RawMessage, domain, host string, ipVersion models.IPVersion,
-	noDNSLookup bool, matcher regex.Matcher) (s Settings, err error) {
+	_ bool, matcher regex.Matcher) (s Settings, err error) {
 	extraSettings := struct {
 		Key string `json:"key"`
 		TTL int    `json:"ttl"`

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -21,7 +21,6 @@ type gandi struct {
 	host      string
 	ttl       int
 	ipVersion models.IPVersion
-	dnsLookup bool
 	key       string
 }
 

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -143,15 +143,6 @@ func (g *gandi) Update(ctx context.Context, client *http.Client, ip net.IP) (new
 		recordType = AAAA
 	}
 
-	recordIP, err := g.getRecordIP(ctx, recordType, client)
-	if err != nil && err != ErrNoResultReceived { // if no ip was defined before, let's proceed with the update
-		return nil, fmt.Errorf("%s: %w", ErrGetRecordIP, err)
-	}
-
-	oldIP := net.ParseIP(recordIP)
-	if ip.Equal(oldIP) { // success, nothing to change
-		return ip, nil
-	}
 
 	u := url.URL{
 		Scheme: "https",

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -14,7 +14,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/regex"
 )
 
-const DEFAULT_TTL = 3600
+const DefaultTTL = 3600
 
 type gandi struct {
 	domain    string
@@ -170,11 +170,11 @@ func (d *gandi) Update(ctx context.Context, client *http.Client, ip net.IP) (new
 	}{
 		Values: [1]string{ip.To4().String()},
 		TTL: func() int {
-			if d.ttl == 0 {
-				return DEFAULT_TTL
-			} else {
-				return d.ttl
+			ttl := DefaultTTL
+			if d.ttl != 0 {
+				ttl = d.ttl
 			}
+			return ttl
 		}(),
 	}
 	if err := encoder.Encode(requestData); err != nil {

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -64,7 +64,7 @@ func (g *gandi) Host() string {
 }
 
 func (g *gandi) DNSLookup() bool {
-	return true
+	return false
 }
 
 func (g *gandi) IPVersion() models.IPVersion {
@@ -119,7 +119,7 @@ func (g *gandi) Update(ctx context.Context, client *http.Client, ip net.IP) (new
 		TTL    int       `json:"rrset_ttl"`
 	}{
 		Values: [1]string{ipStr},
-		TTL: ttl,
+		TTL:    ttl,
 	}
 	if err := encoder.Encode(requestData); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrRequestEncode, err)

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -109,18 +109,17 @@ func (g *gandi) Update(ctx context.Context, client *http.Client, ip net.IP) (new
 
 	buffer := bytes.NewBuffer(nil)
 	encoder := json.NewEncoder(buffer)
+	const defaultTTL = 3600
+	ttl := defaultTTL
+	if g.ttl != 0 {
+		ttl = g.ttl
+	}
 	requestData := struct {
 		Values [1]string `json:"rrset_values"`
 		TTL    int       `json:"rrset_ttl"`
 	}{
 		Values: [1]string{ipStr},
-		TTL: func() int {
-			ttl := 3600
-			if g.ttl != 0 {
-				ttl = g.ttl
-			}
-			return ttl
-		}(),
+		TTL: ttl,
 	}
 	if err := encoder.Encode(requestData); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrRequestEncode, err)

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -67,7 +67,7 @@ func (g *gandi) Host() string {
 }
 
 func (g *gandi) DNSLookup() bool {
-	return g.dnsLookup
+	return true
 }
 
 func (g *gandi) IPVersion() models.IPVersion {

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -14,7 +14,6 @@ import (
 	"github.com/qdm12/ddns-updater/internal/regex"
 )
 
-const DefaultTTL = 3600
 
 type gandi struct {
 	domain    string

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -1,0 +1,202 @@
+package settings
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/qdm12/ddns-updater/internal/constants"
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/regex"
+)
+
+const DEFAULT_TTL = 3600
+
+type gandi struct {
+	domain    string
+	host      string
+	name      string
+	ttl       int
+	ipVersion models.IPVersion
+	dnsLookup bool
+	key       string
+}
+
+func NewGandi(data json.RawMessage, domain, host string, ipVersion models.IPVersion,
+	noDNSLookup bool, matcher regex.Matcher) (s Settings, err error) {
+	extraSettings := struct {
+		Name string `json:"name"`
+		Key  string `json:"key"`
+		TTL  int    `json:"ttl"`
+	}{}
+	if err := json.Unmarshal(data, &extraSettings); err != nil {
+		return nil, err
+	}
+	d := &gandi{
+		domain:    domain,
+		host:      host,
+		ipVersion: ipVersion,
+		dnsLookup: !noDNSLookup,
+		name:      extraSettings.Name,
+		key:       extraSettings.Key,
+		ttl:       extraSettings.TTL,
+	}
+	if err := d.isValid(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func (d *gandi) isValid() error {
+	if len(d.key) == 0 {
+		return ErrEmptyKey
+	}
+	return nil
+}
+
+func (d *gandi) String() string {
+	return toString(d.domain, d.host, constants.GANDI, d.ipVersion)
+}
+
+func (d *gandi) Domain() string {
+	return d.domain
+}
+
+func (d *gandi) Host() string {
+	return d.host
+}
+
+func (d *gandi) DNSLookup() bool {
+	return d.dnsLookup
+}
+
+func (d *gandi) IPVersion() models.IPVersion {
+	return d.ipVersion
+}
+
+func (d *gandi) BuildDomainName() string {
+	return buildDomainName(d.host, d.domain)
+}
+
+func (d *gandi) HTML() models.HTMLRow {
+	return models.HTMLRow{
+		Domain:    models.HTML(fmt.Sprintf("<a href=\"http://%s\">%s</a>", d.BuildDomainName(), d.BuildDomainName())),
+		Host:      models.HTML(d.Host()),
+		Provider:  "<a href=\"https://www.gandi.net/\">gandi</a>",
+		IPVersion: models.HTML(d.ipVersion),
+	}
+}
+
+func (d *gandi) setHeaders(request *http.Request) {
+	setUserAgent(request)
+	setContentType(request, "application/json")
+	setAccept(request, "application/json")
+	request.Header.Set("X-Api-Key", d.key)
+}
+
+func (d *gandi) getRecordIP(ctx context.Context, recordType string, client *http.Client) (
+	recordIP string, err error) {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "dns.api.gandi.net",
+		Path:   fmt.Sprintf("/api/v5/domains/%s/records/%s/%s", d.domain, d.name, recordType),
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	d.setHeaders(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: %d: %s",
+			ErrBadHTTPStatus, response.StatusCode, bodyToSingleLine(response.Body))
+	}
+
+	decoder := json.NewDecoder(response.Body)
+	var result struct {
+		Type   string   `json:"rrset_type"`
+		TTL    int      `json:"rrset_ttl"`
+		Name   string   `json:"rrset_name"`
+		Href   string   `json:"rrset_href"`
+		Values []string `json:"rrset_values"`
+	}
+	if err = decoder.Decode(&result); err != nil {
+		return "", fmt.Errorf("%w: %s", ErrUnmarshalResponse, err)
+	}
+	if len(result.Values) == 0 {
+		return "", ErrNoResultReceived
+	}
+	return result.Values[0], nil
+}
+
+func (d *gandi) Update(ctx context.Context, client *http.Client, ip net.IP) (newIP net.IP, err error) {
+	recordType := A
+	if ip.To4() == nil { // IPv6
+		recordType = AAAA
+	}
+
+	recordIP, err := d.getRecordIP(ctx, recordType, client)
+	if err != nil && err != ErrNoResultReceived { // if no ip was defined before, let's proceed with the update
+		return nil, fmt.Errorf("%s: %w", ErrGetRecordIP, err)
+	}
+
+	oldIP := net.ParseIP(recordIP)
+	if ip.Equal(oldIP) { // success, nothing to change
+		return ip, nil
+	}
+
+	u := url.URL{
+		Scheme: "https",
+		Host:   "dns.api.gandi.net",
+		Path:   fmt.Sprintf("/api/v5/domains/%s/records/%s/%s", d.domain, d.name, recordType),
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	encoder := json.NewEncoder(buffer)
+	requestData := struct {
+		Values [1]string `json:"rrset_values"`
+		TTL    int       `json:"rrset_ttl"`
+	}{
+		Values: [1]string{ip.To4().String()},
+		TTL: func() int {
+			if d.ttl == 0 {
+				return DEFAULT_TTL
+			} else {
+				return d.ttl
+			}
+		}(),
+	}
+	if err := encoder.Encode(requestData); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrRequestEncode, err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), buffer)
+	if err != nil {
+		return nil, err
+	}
+	d.setHeaders(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("%w: %d: %s",
+			ErrBadHTTPStatus, response.StatusCode, bodyToSingleLine(response.Body))
+	}
+
+	return ip, nil
+}

--- a/internal/settings/gandi.go
+++ b/internal/settings/gandi.go
@@ -19,7 +19,6 @@ const DefaultTTL = 3600
 type gandi struct {
 	domain    string
 	host      string
-	name      string
 	ttl       int
 	ipVersion models.IPVersion
 	dnsLookup bool
@@ -29,9 +28,8 @@ type gandi struct {
 func NewGandi(data json.RawMessage, domain, host string, ipVersion models.IPVersion,
 	noDNSLookup bool, matcher regex.Matcher) (s Settings, err error) {
 	extraSettings := struct {
-		Name string `json:"name"`
-		Key  string `json:"key"`
-		TTL  int    `json:"ttl"`
+		Key string `json:"key"`
+		TTL int    `json:"ttl"`
 	}{}
 	if err := json.Unmarshal(data, &extraSettings); err != nil {
 		return nil, err
@@ -41,7 +39,6 @@ func NewGandi(data json.RawMessage, domain, host string, ipVersion models.IPVers
 		host:      host,
 		ipVersion: ipVersion,
 		dnsLookup: !noDNSLookup,
-		name:      extraSettings.Name,
 		key:       extraSettings.Key,
 		ttl:       extraSettings.TTL,
 	}
@@ -103,7 +100,7 @@ func (d *gandi) getRecordIP(ctx context.Context, recordType string, client *http
 	u := url.URL{
 		Scheme: "https",
 		Host:   "dns.api.gandi.net",
-		Path:   fmt.Sprintf("/api/v5/domains/%s/records/%s/%s", d.domain, d.name, recordType),
+		Path:   fmt.Sprintf("/api/v5/domains/%s/records/%s/%s", d.domain, d.host, recordType),
 	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
@@ -159,7 +156,7 @@ func (d *gandi) Update(ctx context.Context, client *http.Client, ip net.IP) (new
 	u := url.URL{
 		Scheme: "https",
 		Host:   "dns.api.gandi.net",
-		Path:   fmt.Sprintf("/api/v5/domains/%s/records/%s/%s", d.domain, d.name, recordType),
+		Path:   fmt.Sprintf("/api/v5/domains/%s/records/%s/%s", d.domain, d.host, recordType),
 	}
 
 	buffer := bytes.NewBuffer(nil)


### PR DESCRIPTION
Add support for http://gandi.net/ registrar

Notes:

- this implementation uses gandiv5 API
- Gandi API defaults to a TTL of 10800 when no TTL is provided when we do a PUT request to update the record. I set the default TTL to 3600 in ddns-updater but it can be overwritten from the configuration

please let me know what you think @qdm12  

This PR resolves https://github.com/qdm12/ddns-updater/issues/150