### PR TITLE
fix(config): Read case sensitive CONFIG

### DIFF
--- a/internal/params/json.go
+++ b/internal/params/json.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/regex"
 	"github.com/qdm12/ddns-updater/internal/settings"
 	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+	"github.com/qdm12/golibs/params"
 )
 
 type commonSettings struct {
@@ -43,7 +44,7 @@ func (r *reader) getSettingsFromFile(filePath string) (allSettings []settings.Se
 
 // getSettingsFromEnv obtain the update settings from the environment variable CONFIG.
 func (r *reader) getSettingsFromEnv() (allSettings []settings.Settings, warnings []string, err error) {
-	s, err := r.env.Get("CONFIG")
+	s, err := r.env.Get("CONFIG", params.CaseSensitiveValue())
 	if err != nil {
 		return nil, nil, err
 	} else if len(s) == 0 {


### PR DESCRIPTION
Read the case sensitive value of the config file when using the CONFIG environment variable.
Converting the string to lowercase breaks case sensitive api keys/secrets for GoDaddy (and possibly
other providers).

Signed-off-by: Matthew Hill <matthewchill7@gmail.com>

Possibly solves #91.