### PR TITLE
Fix issue with slash in branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
             echo ::set-output name=version::latest
             echo ::set-output name=platforms::linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7,linux/s390x,linux/ppc64le,linux/riscv64
           else
-            echo ::set-output name=version::$BRANCH
+            echo ::set-output name=version::${BRANCH##*/}
             echo ::set-output name=platforms::linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7
           fi
 


### PR DESCRIPTION
allow well-known git convention to be used.
1) the convention is given in the git book https://git-scm.com/book/en/v2/Distributed-Git-Maintaining-a-Project
2) branches with a prefix before the `/` appear hierarchically grouped in some git clients like gitkraken