### PR TITLE
Updated Example for Google Provider

### DIFF
--- a/docs/google.md
+++ b/docs/google.md
@@ -8,7 +8,7 @@
 {
   "settings": [
     {
-      "provider": "godaddy",
+      "provider": "google",
       "domain": "domain.com",
       "host": "@",
       "username": "username",


### PR DESCRIPTION
Corrected provider name in JSON example from "godaddy" to "google"