### PR TITLE
Match configured host for LuaDNS instead of first A/AAAA record

### DIFF
--- a/internal/settings/providers/luadns/provider.go
+++ b/internal/settings/providers/luadns/provider.go
@@ -225,8 +225,9 @@ func (p *provider) getRecord(ctx context.Context, client *http.Client, zoneID in
 	if ip.To4() == nil {
 		recordType = constants.AAAA
 	}
+	
 	for _, record := range records {
-		if record.Type == recordType {
+		if record.Type == recordType && record.Name == utils.BuildURLQueryHostname(p.host, p.domain) {
 			return record, nil
 		}
 	}


### PR DESCRIPTION
I don't have an easy way to test this, but the change was loosely lifted from the dreamhost provider