### PR TITLE
Add caching to improve build time performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,13 @@ jobs:
         with:
           target: base
           load: true
+          outputs: type=docker
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-to: |
+            type=local,dest=/tmp/.buildx-cache-new,mode=max
+            type=inline
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,32 @@ jobs:
           locale: "US"
           level: error
 
+      - uses: docker/setup-buildx-action@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and cache base image layers
+        uses: docker/build-push-action@v4
+        with:
+          target: base
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
       - name: Linting
         run: docker build --target lint .
 


### PR DESCRIPTION
Uses the builtin `cache-from`/`cache-to` options from the `docker/buil-push-action` to write out the buildx cache.
Using the github `actions/cache` action the buildx cache is stored by github for future runs.