### PR TITLE
Bumps versions of all GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Linting
         run: docker build --target lint .
@@ -53,18 +53,18 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
 
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           username: qmcgaw
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Build and push final image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           platforms: ${{ steps.vars.outputs.platforms }}
           build-args: |

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2.1.0
+        uses: peter-evans/dockerhub-description@v3.1.0
         env:
           DOCKERHUB_USERNAME: qmcgaw
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: crazy-max/ghaction-github-labeler@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR update all the actions to the latest current versions.  Naturally, the publish step fails for me, as I don't have secrets, etc setup for login.  It looks like 95% of the major version bumps are for using Node 16 as the default runtime, which isn't an issue for running hosted here.

The labeler action had the largest bump, so I updated it a tiny bit to account for the token being an input now (changed in [v3](https://github.com/crazy-max/ghaction-github-labeler/releases/tag/v3.0.0))