### PR TITLE
docs(readme): document `SHOUTRRR_PARAMS` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Note that:
 | `LOG_LEVEL` | `info` | Level of logging, `debug`, `info`, `warning` or `error` |
 | `LOG_CALLER` | `hidden` | Show caller per log line, `hidden` or `short` |
 | `SHOUTRRR_ADDRESSES` |  | (optional) Comma separated list of [Shoutrrr addresses](https://containrrr.dev/shoutrrr/services/overview/) (notification services) |
+| `SHOUTRRR_PARAMS` |  | (optional) Comma separated list of Shoutrrr parameters (different per service). Set this to `contenttype=text/plain` when using the Generic Shoutrrr service since the default is `application/json`, but ddns-updater sends plain text.  |
 | `TZ` | | Timezone to have accurate times, i.e. `America/Montreal` |
 
 #### Public IP

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Note that:
 | `LOG_LEVEL` | `info` | Level of logging, `debug`, `info`, `warning` or `error` |
 | `LOG_CALLER` | `hidden` | Show caller per log line, `hidden` or `short` |
 | `SHOUTRRR_ADDRESSES` |  | (optional) Comma separated list of [Shoutrrr addresses](https://containrrr.dev/shoutrrr/services/overview/) (notification services) |
-| `SHOUTRRR_PARAMS` |  | (optional) Comma separated list of Shoutrrr parameters (different per service). Set this to `contenttype=text/plain` when using the Generic Shoutrrr service since the default is `application/json`, but ddns-updater sends plain text.  |
+| `SHOUTRRR_PARAMS` | `title=DDNS Updater` | (optional) Comma separated list of Shoutrrr parameters (different per service). |
 | `TZ` | | Timezone to have accurate times, i.e. `America/Montreal` |
 
 #### Public IP

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Note that:
 | `LOG_LEVEL` | `info` | Level of logging, `debug`, `info`, `warning` or `error` |
 | `LOG_CALLER` | `hidden` | Show caller per log line, `hidden` or `short` |
 | `SHOUTRRR_ADDRESSES` |  | (optional) Comma separated list of [Shoutrrr addresses](https://containrrr.dev/shoutrrr/services/overview/) (notification services) |
-| `SHOUTRRR_PARAMS` | `title=DDNS Updater` | (optional) Comma separated list of Shoutrrr parameters (different per service). |
+| `SHOUTRRR_PARAMS` | `title=DDNS Updater` | (optional) Comma separated list of Shoutrrr parameters. ⚠️ #416 |
 | `TZ` | | Timezone to have accurate times, i.e. `America/Montreal` |
 
 #### Public IP


### PR DESCRIPTION
Found the environment variable SHOUTRRR_PARAMS in the code but not documented.

It is also necessary because by default ddns-updater sends plain text via Shoutrrr but sets the content type to `application/json` (invalid).

Even better would be a small usage example for Shoutrrr such as:

```
    --env SHOUTRRR_ADDRESSES="generic://<shoutrrr-webhook-endpoint-url>" \
    --env SHOUTRRR_PARAMS="contenttype=text/plain" \
```
but I didn't know where to add this to the readme.