### PR TITLE
docs: add missing `provider_ip` field in examples 

### DIFF
--- a/docs/he.net.md
+++ b/docs/he.net.md
@@ -12,6 +12,7 @@
       "domain": "domain.com",
       "host": "@",
       "password": "password",
+      "provider_ip": true,
       "ip_version": "ipv4"
     }
   ]
@@ -27,5 +28,6 @@
 ### Optional parameters
 
 - `"ip_version"` can be `ipv4` (A records) or `ipv6` (AAAA records), defaults to `ipv4 or ipv6`
+- `"provider_ip"` can be set to `true` to let your DNS provider determine your IPv4 address (and/or IPv6 address) automatically when you send an update request, without sending the new IP address detected by the program in the request.
 
 ## Domain setup

--- a/docs/selfhost.de.md
+++ b/docs/selfhost.de.md
@@ -13,6 +13,7 @@
       "host": "@",
       "username": "username",
       "password": "password",
+      "provider_ip": true,
       "ip_version": "ipv4"
     }
   ]
@@ -29,5 +30,6 @@
 ### Optional parameters
 
 - `"ip_version"` can be `ipv4` (A records) or `ipv6` (AAAA records), defaults to `ipv4 or ipv6`
+- `"provider_ip"` can be set to `true` to let your DNS provider determine your IPv4 address (and/or IPv6 address) automatically when you send an update request, without sending the new IP address detected by the program in the request.
 
 ## Domain setup

--- a/docs/servercow.md
+++ b/docs/servercow.md
@@ -14,6 +14,7 @@
           "username": "servercow_username",
           "password": "servercow_password",
           "ttl": 600,
+          "provider_ip": true,
           "ip_version": "ipv4"
       }
   ]
@@ -31,6 +32,7 @@
 
 - `"ttl"` can be set to an integer value for record TTL in seconds (if not set the default is 120)
 - `"ip_version"` can be `ipv4` (A records) or `ipv6` (AAAA records), and defaults to `ipv4 or ipv6`
+- `"provider_ip"` can be set to `true` to let your DNS provider determine your IPv4 address (and/or IPv6 address) automatically when you send an update request, without sending the new IP address detected by the program in the request.
 
 ## Domain setup
 


### PR DESCRIPTION
- he.net
- selfhost.de
- servercow