### PR TITLE
possible fix for panic on inwx

### DIFF
--- a/internal/settings/providers/inwx/provider.go
+++ b/internal/settings/providers/inwx/provider.go
@@ -101,7 +101,7 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip net.IP) (
 		Host:   "dyndns.inwx.com",
 		Path:   "/nic/update",
 	}
-	var values url.Values
+	values := url.Values{}
 	values.Set("hostname", utils.BuildURLQueryHostname(p.host, p.domain))
 	if ip.To4() != nil {
 		values.Set("myip", ip.String())


### PR DESCRIPTION
I was getting a panic for inwx provider, from looking in the other providers looks like others was using this format instead of `var`.

I have no Go Experiene, so this might be plain wrong.

Here is the panic.
```
panic: assignment to entry in nil map

goroutine 71 [running]:
net/url.Values.Set(...)
        net/url/url.go:899
github.com/qdm12/ddns-updater/internal/settings/providers/inwx.(*Provider).Update(0xc0003181e0, {0xdd4848, 0xc00071e9b0}, 0x0?, {0xc000492120, 0x10, 0x10})
        github.com/qdm12/ddns-updater/internal/settings/providers/inwx/provider.go:105 +0x27f
github.com/qdm12/ddns-updater/internal/update.(*Updater).Update(0xc000473740, {0xdd4848, 0xc00071e9b0}, 0xc10d1553dff45507?, {0xc000492120, 0x10, 0x10}, {0xc10d1553e10ebfd9, 0x1aa5cfc3, 0x130cec0})
        github.com/qdm12/ddns-updater/internal/update/update.go:47 +0x22e
github.com/qdm12/ddns-updater/internal/update.(*Runner).updateNecessary(0xc000474630, {0xdd4848, 0xc00071e9b0}, {0xc00071c0c0, 0x10, 0x10})
        github.com/qdm12/ddns-updater/internal/update/run.go:289 +0xa7d
github.com/qdm12/ddns-updater/internal/update.(*Runner).Run(0xc000474630, {0xdd4848, 0xc00071e9b0}, 0x0?)
        github.com/qdm12/ddns-updater/internal/update/run.go:307 +0x15d
created by main._main
        ./main.go:238 +0x160a
```