### PR TITLE
docs(readme): pin shoutrrr link to go.mod shoutrrr version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,9 @@
 .vscode
 docs
 readme
+!readme/*.go
 .gitignore
 config.json
 docker-compose.yml
 LICENSE
-README.md
 ui/favicon.svg

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ FROM --platform=$BUILDPLATFORM base AS test
 # - we set CGO_ENABLED=1 to have it enabled
 # - we installed g++ to support the race detector
 ENV CGO_ENABLED=1
+COPY readme/ ./readme/
+COPY README.md ./README.md
 ENTRYPOINT go test -race -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic ./...
 
 FROM --platform=$BUILDPLATFORM base AS lint

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Light container updating DNS A and/or AAAA records periodically for multiple DNS
 - Persistence with a JSON file *updates.json* to store old IP addresses with change times for each record
 - Docker healthcheck verifying the DNS resolution of your domains
 - Highly configurable
-- Send notifications with [**Shoutrrr**](https://containrrr.dev/shoutrrr/services/overview/) using `SHOUTRRR_ADDRESSES`
+- Send notifications with [**Shoutrrr**](https://containrrr.dev/shoutrrr/0.7/services/overview/) using `SHOUTRRR_ADDRESSES`
 - Compatible with `amd64`, `386`, `arm64`, `armv7`, `armv6`, `s390x`, `ppc64le`, `riscv64` CPU architectures.
 
 ## Setup

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/qdm12/gotree v0.2.0
 	github.com/qdm12/log v0.1.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/mod v0.8.0
 	golang.org/x/net v0.10.0
 	google.golang.org/api v0.102.0
 )
@@ -33,7 +34,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
-	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/readme/shoutrrr_version_test.go
+++ b/readme/shoutrrr_version_test.go
@@ -1,0 +1,55 @@
+package readme
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
+)
+
+var regexShoutrrrURL = regexp.MustCompile(`https://containrrr.dev/shoutrrr/[0-9.]+/services/overview/`)
+
+func Test_Readme_Shoutrrr_Version(t *testing.T) {
+	t.Parallel()
+
+	goModBytes, err := os.ReadFile("../go.mod")
+	require.NoError(t, err)
+
+	goMod, err := modfile.Parse("../go.mod", goModBytes, nil)
+	require.NoError(t, err)
+
+	shoutrrrVersion := ""
+	for _, require := range goMod.Require {
+		if require.Mod.Path != "github.com/containrrr/shoutrrr" {
+			continue
+		}
+		shoutrrrVersion = require.Mod.Version
+	}
+	require.NotEmpty(t, shoutrrrVersion)
+
+	// Remove prefix "v" and bugfix suffix from version
+	urlShoutrrrVersion := strings.TrimPrefix(shoutrrrVersion, "v")
+	lastDot := strings.LastIndex(urlShoutrrrVersion, ".")
+	require.GreaterOrEqual(t, lastDot, 0)
+	urlShoutrrrVersion = urlShoutrrrVersion[:lastDot]
+
+	expectedShoutrrrURL := "https://containrrr.dev/shoutrrr/" +
+		urlShoutrrrVersion + "/services/overview/"
+
+	readmeBytes, err := os.ReadFile("../README.md")
+	require.NoError(t, err)
+	readmeString := string(readmeBytes)
+
+	readmeShoutrrrURLs := regexShoutrrrURL.FindAllString(readmeString, -1)
+	require.NotEmpty(t, readmeShoutrrrURLs)
+
+	for _, readmeShoutrrrURL := range readmeShoutrrrURLs {
+		if readmeShoutrrrURL != expectedShoutrrrURL {
+			t.Errorf("README.md contains outdated shoutrrr URL: %s should be %s",
+				readmeShoutrrrURL, expectedShoutrrrURL)
+		}
+	}
+}


### PR DESCRIPTION
In `shoutrrr`, whenever a new service is added, or new features are added to an existing service we bump the minor version and push a new version tag to the docs. This allows consumers of the library to link directly to the documentation for the version they are currently using, avoiding confusion about missing features.
 
This PR adds the `0.7` version to the README which of course should be updated whenever the dependency is updated. Feel free to opt out of this by closing the PR 😁.