### PR TITLE
Include ipversion in string representation of all providers

### DIFF
--- a/internal/provider/providers/desec/provider.go
+++ b/internal/provider/providers/desec/provider.go
@@ -61,7 +61,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: deSEC]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.DeSEC, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/dyn/provider.go
+++ b/internal/provider/providers/dyn/provider.go
@@ -73,7 +73,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Dyn]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.Dyn, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/dynv6/provider.go
+++ b/internal/provider/providers/dynv6/provider.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
 	"github.com/qdm12/ddns-updater/internal/provider/headers"
 	"github.com/qdm12/ddns-updater/internal/provider/utils"
@@ -58,7 +59,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: DynV6]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.DynV6, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/inwx/provider.go
+++ b/internal/provider/providers/inwx/provider.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
 	"github.com/qdm12/ddns-updater/internal/provider/headers"
 	"github.com/qdm12/ddns-updater/internal/provider/utils"
@@ -62,7 +63,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: INWX]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.INWX, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/opendns/provider.go
+++ b/internal/provider/providers/opendns/provider.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
 	"github.com/qdm12/ddns-updater/internal/provider/headers"
 	"github.com/qdm12/ddns-updater/internal/provider/utils"
@@ -65,7 +66,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Opendns]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.OpenDNS, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/ovh/provider.go
+++ b/internal/provider/providers/ovh/provider.go
@@ -102,7 +102,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: OVH]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.OVH, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/porkbun/provider.go
+++ b/internal/provider/providers/porkbun/provider.go
@@ -63,7 +63,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Porkbun]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.Porkbun, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/selfhostde/provider.go
+++ b/internal/provider/providers/selfhostde/provider.go
@@ -66,7 +66,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Selfhost.de]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.SelfhostDe, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/spdyn/provider.go
+++ b/internal/provider/providers/spdyn/provider.go
@@ -72,7 +72,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Spdyn]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.Spdyn, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/strato/provider.go
+++ b/internal/provider/providers/strato/provider.go
@@ -61,7 +61,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Strato]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.Strato, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {

--- a/internal/provider/providers/variomedia/provider.go
+++ b/internal/provider/providers/variomedia/provider.go
@@ -66,7 +66,7 @@ func (p *Provider) isValid() error {
 }
 
 func (p *Provider) String() string {
-	return fmt.Sprintf("[domain: %s | host: %s | provider: Variomedia]", p.domain, p.host)
+	return utils.ToString(p.domain, p.host, constants.Variomedia, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {


### PR DESCRIPTION
I'm using two providers (cloudflare and strato) and noticed that for strato, the logs don't show the configured IP version(s). This PR changes the string representation of the Strato provider to include the ip version:

Before:

```
ddns-updater  | 2023-07-19T08:27:42Z INFO Updating record [domain: mydomain.com | host: @ | provider: Strato] to use 2001:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:c091
ddns-updater  | 2023-07-19T08:32:41Z INFO Updating record [domain: anotherdomain.com | host: @ | provider: cloudflare | ip: ipv6] to use 2001:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:c091
```

After:

```
ddns-updater  | 2023-07-19T08:27:42Z INFO Updating record [domain: mydomain.com | host: @ | provider: strato | ip: ipv6] to use 2001:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:c091
ddns-updater  | 2023-07-19T08:32:41Z INFO Updating record [domain: anotherdomain.com | host: @ | provider: cloudflare | ip: ipv6] to use 2001:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:c091
```

I noticed that out of the 40 providers 30 use `utils.ToString` and 10 (still?) use `fmt.Sprintf("[domain: %s ...`. I can change the remaining 9 as well if you want. 

Let me know what you think.

BTW: This is the first time I've worked with Go and the Devcontainer made it super easy to get started. Thanks for providing that, it makes a big difference in the required effort to get set up!

Edit: Changed the string representation of all providers to include the ipversion