### PR TITLE
Group records in database by `ipVersion`

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -191,8 +191,10 @@ func _main(ctx context.Context, settingsSource SettingsSource, args []string, lo
 	records := make([]recordslib.Record, len(providers))
 	for i, provider := range providers {
 		logger.Info("Reading history from database: domain " +
-			provider.Domain() + " host " + provider.Host())
-		events, err := persistentDB.GetEvents(provider.Domain(), provider.Host())
+			provider.Domain() + " host " + provider.Host() +
+			" " + provider.IPVersion().String())
+		events, err := persistentDB.GetEvents(provider.Domain(),
+			provider.Host(), provider.IPVersion())
 		if err != nil {
 			shoutrrrClient.Notify(err.Error())
 			return err

--- a/internal/persistence/json/queries.go
+++ b/internal/persistence/json/queries.go
@@ -1,10 +1,12 @@
 package json
 
 import (
+	"fmt"
 	"net/netip"
 	"time"
 
 	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
 )
 
 // StoreNewIP stores a new IP address for a certain domain and host.
@@ -37,15 +39,37 @@ func (db *Database) StoreNewIP(domain, host string, ip netip.Addr, t time.Time) 
 	return db.write()
 }
 
-// GetEvents gets all the IP addresses history for a certain domain and host, in the order
-// from oldest to newest.
-func (db *Database) GetEvents(domain, host string) (events []models.HistoryEvent, err error) {
+// GetEvents gets all the IP addresses history for a certain domain, host and
+// IP version, in the order from oldest to newest.
+func (db *Database) GetEvents(domain, host string,
+	ipVersion ipversion.IPVersion) (events []models.HistoryEvent, err error) {
 	db.RLock()
 	defer db.RUnlock()
 	for _, record := range db.data.Records {
 		if record.Domain == domain && record.Host == host {
-			return append(events, record.Events...), nil
+			return filterEvents(events, ipVersion), nil
 		}
 	}
 	return nil, nil
+}
+
+func filterEvents(events []models.HistoryEvent, ipVersion ipversion.IPVersion) (filteredEvents []models.HistoryEvent) {
+	filteredEvents = make([]models.HistoryEvent, 0, len(events))
+	for _, event := range events {
+		switch ipVersion {
+		case ipversion.IP4:
+			if event.IP.Is4() {
+				filteredEvents = append(filteredEvents, event)
+			}
+		case ipversion.IP6:
+			if event.IP.Is6() {
+				filteredEvents = append(filteredEvents, event)
+			}
+		case ipversion.IP4or6:
+			filteredEvents = append(filteredEvents, event)
+		default:
+			panic(fmt.Sprintf("IP version %v is not supported", ipVersion))
+		}
+	}
+	return filteredEvents
 }


### PR DESCRIPTION
Currently, items in the database (`updates.json`) are grouped by `domain` and `host`. This leads to problems when there are multiple config items that contain the same domain and host.

I'm using two separate config items with the same host and domain but different `ipVersion` values to update both the ipv4 and ipv6 address. In this setup, `ddns-updater` currently uses the history of both ip versions which leads to incorrect info displayed in the UI.

This PR adds `ipVersion` as an additional item that is used to group IPs in the database. With this change, the history is displayed correctly.

Example `config.json`:

```json
{
    "settings": [
        {
            "provider": "strato",
            "domain": "my.domain",
            "host": "@",
            "password": "pw",
            "ip_version": "ipv4",
            "provider_ip": false
        },
        {
            "provider": "strato",
            "domain": "my.domain",
            "host": "@",
            "password": "pw",
            "ip_version": "ipv6",
            "provider_ip": false
        }
    ]
}
```

`updates.json` using current master:

```json
{
    "records": [
      {
        "domain": "my.domain",
        "host": "@",
        "ips": [
          {
            "ip": "2001:fff:8987:4000:3e18:ffff:fe03:ffff",
            "time": "2023-07-30T01:44:10.54280786Z"
          },
          {
            "ip": "97.155.132.1",
            "time": "2023-07-31T01:44:16.306989718Z"
          },
          {
            "ip": "2001:fff:89a4:9a00:3e18:ffff:fe03:ffff",
            "time": "2023-07-31T01:44:16.505670661Z"
          },
          {
            "ip": "2001:fff:8984:1d00:3e18:ffff:fe03:ffff",
            "time": "2023-08-01T01:44:10.520411731Z"
          },
          {
            "ip": "97.155.133.27",
            "time": "2023-08-02T01:39:10.529543713Z"
          },
          {
            "ip": "2001:fff:89a0:f500:3e18:ffff:fe03:ffff",
            "time": "2023-08-02T01:39:10.724642214Z"
          }
        ]
      }
    ]
  }
```

`updates.json` with the changes proposed in this PR:

```json
{
  "records": [
    {
      "domain": "my.domain",
      "host": "@",
      "ipVersion": "ipv4",
      "ips": [
        {
          "ip": "97.155.132.1",
          "time": "2023-07-31T01:44:16.306989718Z"
        },
        {
          "ip": "97.155.133.27",
          "time": "2023-08-02T01:39:10.529543713Z"
        }
      ]
    },
    {
      "domain": "wirth.one",
      "host": "@",
      "ipVersion": "ipv6",
      "ips": [
        {
          "ip": "2001:fff:8987:4000:3e18:ffff:fe03:ffff",
          "time": "2023-07-30T01:44:10.54280786Z"
        },
        {
          "ip": "2001:fff:89a4:9a00:3e18:ffff:fe03:ffff",
          "time": "2023-07-31T01:44:16.505670661Z"
        },
        {
          "ip": "2001:fff:8984:1d00:3e18:ffff:fe03:ffff",
          "time": "2023-08-01T01:44:10.520411731Z"
        },
        {
          "ip": "2001:fff:89a0:f500:3e18:ffff:fe03:ffff",
          "time": "2023-08-02T01:39:10.724642214Z"
        }
      ]
    }
  ]
}
```

UI (current master):
![Screenshot 2023-08-04 150336](https://github.com/qdm12/ddns-updater/assets/104097293/564f038b-7f79-487d-a506-740de4411911)

UI (with the changes proposed here):
![Screenshot 2023-08-04 150147](https://github.com/qdm12/ddns-updater/assets/104097293/5f8cacf1-52f2-4daa-9a1d-1a7dc56f2af2)

Let me know if this looks good to you. Thanks!

