### PR TITLE
duckdns provider fix ipv6 update

### DIFF
--- a/internal/provider/providers/duckdns/provider.go
+++ b/internal/provider/providers/duckdns/provider.go
@@ -109,7 +109,7 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	values.Set("token", p.token)
 	if !p.useProviderIP {
 		if ip.Is6() {
-			values.Set("ip6", ip.String())
+			values.Set("ipv6", ip.String())
 		} else {
 			values.Set("ip", ip.String())
 		}

--- a/internal/provider/providers/duckdns/provider.go
+++ b/internal/provider/providers/duckdns/provider.go
@@ -146,10 +146,11 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	case s[0:minChars] == "KO":
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrAuth)
 	case s[0:minChars] == "OK":
+		var ips []netip.Addr
 		if ip.Is6() {
-			ips := ipextract.IPv6(s)
+			ips = ipextract.IPv6(s)
 		} else {
-		        ips := ipextract.IPv4(s)
+			ips = ipextract.IPv4(s)
 		}
 		if len(ips) == 0 {
 			return netip.Addr{}, fmt.Errorf("%w", errors.ErrReceivedNoIP)

--- a/internal/provider/providers/duckdns/provider.go
+++ b/internal/provider/providers/duckdns/provider.go
@@ -108,11 +108,7 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	values.Set("domains", p.host)
 	values.Set("token", p.token)
 	if !p.useProviderIP {
-		if ip.Is6() {
-			values.Set("ip6", ip.String())
-		} else {
-			values.Set("ip", ip.String())
-		}
+		values.Set("ip", ip.String())
 	}
 	u.RawQuery = values.Encode()
 

--- a/internal/provider/providers/duckdns/provider.go
+++ b/internal/provider/providers/duckdns/provider.go
@@ -108,7 +108,11 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	values.Set("domains", p.host)
 	values.Set("token", p.token)
 	if !p.useProviderIP {
-		values.Set("ip", ip.String())
+		if ip.Is6() {
+			values.Set("ip6", ip.String())
+		} else {
+			values.Set("ip", ip.String())
+		}
 	}
 	u.RawQuery = values.Encode()
 


### PR DESCRIPTION
I am trying to use the duckdns dynamic dns service to assign/update an ipv6. The hostname only has an AAAA record (ipv6) and the A record (ipv4) is empty. 
I have encountered two issues that should be fixed with this PR:

~First: according to the [api documentation](https://www.duckdns.org/spec.jsp)~
> If you do not specify the IP address, then it will be detected - this only works for IPv4 addresses
You can put either an IPv4 or an IPv6 address in the ip parameter
If you want to update BOTH of your IPv4 and IPv6 records at once, then you can use the optional parameter ipv6

~The current code in case of ipv4 correctly uses the ip parameter. But in case of ipv6, the ipv6 parameter is used alone without the ip parameter. 
This leads to the following behavior:~
* ~The AAAA record is updated with the new ipv6 as expected~
* ~As the ip parameter is empty, the ipv4 is automatically detected by duckdns~
* ~The A record is updated with the found ipv4~

~In my case, the found ipv4 is some isp provided NAT that I have no control over. So the current behavior is wrong for my use case, but I think it is also not what is intended here.~

~The proposed change sends both ipv4 and ipv6 to the ip parameter which is the correct thing according to the documentation when updating the ipv6 only.~

Edit: after some testing on the command line it seems that the current implementation is correct and the documentation is wrong. I have reverted this part of the PR.
Edit2: the parameter name was wrong. That was why I got an ipv4 update with your code but an ipv6 update on the command line.

Second: when verifying the updated ip, the current code assumes that the ip is ipv4 always. This PR adds the ipv6 case.
