### PR TITLE
Gandi Personal Access Token support

### DIFF
--- a/docs/gandi.md
+++ b/docs/gandi.md
@@ -13,8 +13,7 @@ This provider uses Gandi v5 API
       "provider": "gandi",
       "domain": "domain.com",
       "host": "@",
-      "key": "key",
-      "token": "token",
+      "personal_access_token": "token",
       "ttl": 3600,
       "ip_version": "ipv4"
     }
@@ -26,8 +25,7 @@ This provider uses Gandi v5 API
 
 - `"domain"`
 - `"host"` which can be a subdomain, `@` or a wildcard `*`
-- Either a Gandi API Key `"key"` or Gandi Personal Access Token `"token"` must be provided.
-- If both a `"key"` and `"token"` are provided, the `"token"` will be used.
+- `"personal_access_token"`
 
 ### Optional parameters
 
@@ -36,4 +34,4 @@ This provider uses Gandi v5 API
 
 ## Domain setup
 
-[Gandi Documentation Website](https://docs.gandi.net/en/domain_names/advanced_users/api.html#gandi-s-api)
+[Gandi Documentation Website](https://docs.gandi.net/en/rest_api/index.html)

--- a/docs/gandi.md
+++ b/docs/gandi.md
@@ -14,6 +14,7 @@ This provider uses Gandi v5 API
       "domain": "domain.com",
       "host": "@",
       "key": "key",
+      "token": "token",
       "ttl": 3600,
       "ip_version": "ipv4"
     }
@@ -25,7 +26,8 @@ This provider uses Gandi v5 API
 
 - `"domain"`
 - `"host"` which can be a subdomain, `@` or a wildcard `*`
-- `"key"`
+- Either a Gandi API Key `"key"` or Gandi Personal Access Token `"token"` must be provided.
+- If both a `"key"` and `"token"` are provided, the `"token"` will be used.
 
 ### Optional parameters
 

--- a/internal/provider/providers/gandi/provider.go
+++ b/internal/provider/providers/gandi/provider.go
@@ -54,7 +54,7 @@ func New(data json.RawMessage, domain, host string,
 
 func (p *Provider) isValid() error {
 	if p.key == "" && p.token == "" { // checks if both API Key and Token are not set
-		return fmt.Errorf("%w This one", errors.ErrKeyNotSet)
+		return fmt.Errorf("%w", errors.ErrKeyNotSet)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently authentication for updates to Gandi domains can only be done with the Gandi API key. [Gandi has depreciated the API key in favor of Personal Access Tokens. 
](https://api.gandi.net/docs/authentication/)
This PR adds the option to authenticate using a Personal Access Tokens but does not require a token to be used instead of an API key. This should not break anyone's current configurations or require updates to their configuration files. This implementation produces a KeyNotSet error only if both the API Key and Personal Access Token are not provided or are empty the config file. If both an API key and Personal Access Token are provided, it will default to using the Token for authentication. It does not use the API key as a fall back (i.e. if authentication via Token fails, try again with the API key), but this could be implemented in the future if desired.

Example config.json with different possible valid configurations:
```
{
    "settings": [
        {
            "provider": "gandi",
            "domain": "mydomain.com",
            "host": "@",
            "key": "mysecretkey",
            "ip_version": "ipv4"
        },
        {
            "provider": "gandi",
            "domain": "mydomain.com",
            "host": "@",
            "token": "mypersonalaccesstoken",
            "ip_version": "ipv4"
        },
        {
            "provider": "gandi",
            "domain": "mydomain.com",
            "host": "@",
            "key": "mysecretkey",
            "token": "mypersonalaccesstoken",
            "ip_version": "ipv4"
        }
    ]
}
```