### PR TITLE
Provider Porkbun: Fix wildcard domain modifications

### DIFF
--- a/internal/provider/providers/porkbun/api.go
+++ b/internal/provider/providers/porkbun/api.go
@@ -20,9 +20,6 @@ func (p *Provider) getRecordIDs(ctx context.Context, client *http.Client, record
 		Host:   "porkbun.com",
 		Path:   "/api/json/v3/dns/retrieveByNameType/" + p.domain + "/" + recordType + "/",
 	}
-	if p.owner != "@" && p.owner != "*" {
-		u.Path += p.owner
-	}
 
 	postRecordsParams := struct {
 		SecretAPIKey string `json:"secretapikey"`
@@ -38,7 +35,14 @@ func (p *Provider) getRecordIDs(ctx context.Context, client *http.Client, record
 		return nil, fmt.Errorf("json encoding request data: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), buffer)
+	encodedRequestURL := u.String()
+	if p.owner != "@" {
+		// add owner after string-ing the URL to avoid encoding the '*' character,
+		// since Porkbun requires we send the unencoded '*' character.
+		encodedRequestURL += p.owner
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, encodedRequestURL, buffer)
 	if err != nil {
 		return nil, fmt.Errorf("creating http request: %w", err)
 	}
@@ -173,14 +177,11 @@ func (p *Provider) updateRecord(ctx context.Context, client *http.Client,
 
 // See https://porkbun.com/api/json/v3/documentation#DNS%20Delete%20Records%20by%20Domain,%20Subdomain%20and%20Type
 func (p *Provider) deleteAliasRecord(ctx context.Context, client *http.Client) (err error) {
-	var subdomain string
-	if p.owner != "@" {
-		subdomain = p.owner
-	}
 	u := url.URL{
 		Scheme: "https",
 		Host:   "porkbun.com",
-		Path:   "/api/json/v3/dns/deleteByNameType/" + p.domain + "/ALIAS/" + subdomain,
+		// owner is added below after string-ing the URL
+		Path: "/api/json/v3/dns/deleteByNameType/" + p.domain + "/ALIAS/",
 	}
 	postRecordsParams := struct {
 		SecretAPIKey string `json:"secretapikey"`
@@ -196,7 +197,14 @@ func (p *Provider) deleteAliasRecord(ctx context.Context, client *http.Client) (
 		return fmt.Errorf("json encoding request data: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), buffer)
+	encodedRequestURL := u.String()
+	if p.owner != "@" {
+		// add owner after string-ing the URL to avoid encoding the '*' character,
+		// since Porkbun requires we send the unencoded '*' character.
+		encodedRequestURL += p.owner
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, encodedRequestURL, buffer)
 	if err != nil {
 		return fmt.Errorf("creating http request: %w", err)
 	}


### PR DESCRIPTION
# Description
Porkbun does not properly handle wildcard domains with an HTML encoded `*`. By default the URL is encoded, and `*` becomes `%2A` which then causes Porkbun to _not_ return the correct DNS entry for `*.domain.com` resulting in duplicate `*.domain.com` DNS entries and other unwanted behavior. This updates the logic to append the domain owner (subdomain) to the url after HTML encoding it, preventing the '*' or any other subdomain characters from being HTML encoded.

# Test-Plan
Setup several domains with `*.domain.tld` and `domain.tld` dns `A` entries.
Set the values for some dns `A` entries to `127.0.0.1`
Verified that DDNS-Updater was able to correctly update all entries with the invalid IP address set.