### PR TITLE
Provider Porkbun: Remove trailing '.' from alias delete request

### DIFF
--- a/internal/provider/providers/porkbun/api.go
+++ b/internal/provider/providers/porkbun/api.go
@@ -175,7 +175,7 @@ func (p *Provider) updateRecord(ctx context.Context, client *http.Client,
 func (p *Provider) deleteAliasRecord(ctx context.Context, client *http.Client) (err error) {
 	var subdomain string
 	if p.owner != "@" {
-		subdomain = p.owner + "."
+		subdomain = p.owner
 	}
 	u := url.URL{
 		Scheme: "https",


### PR DESCRIPTION
# Description
The porkbun documentation example request to delete a domain does not contain a trailing '.' `URI Endpoint Example: https://api.porkbun.com/api/json/v3/dns/deleteByNameType/borseth.ink/A/www`

This updates the code to match that.

# Test-Plan
Changed delete to allow arbitrary deletes of any type (instead of just ALIAS)
Changed code to delete+create instead of update to change a porkbun domain Verified that delete works by deleting and creating a domain to update it instead of calling the update endpoint.