### PR TITLE
Provider Porkbun: Update delete API to allow arbitrary deletions

### DIFF
--- a/internal/provider/providers/porkbun/api.go
+++ b/internal/provider/providers/porkbun/api.go
@@ -172,7 +172,7 @@ func (p *Provider) updateRecord(ctx context.Context, client *http.Client,
 }
 
 // See https://porkbun.com/api/json/v3/documentation#DNS%20Delete%20Records%20by%20Domain,%20Subdomain%20and%20Type
-func (p *Provider) deleteAliasRecord(ctx context.Context, client *http.Client) (err error) {
+func (p *Provider) deleteRecord(ctx context.Context, client *http.Client, recordType string) (err error) {
 	var subdomain string
 	if p.owner != "@" {
 		subdomain = p.owner
@@ -180,7 +180,7 @@ func (p *Provider) deleteAliasRecord(ctx context.Context, client *http.Client) (
 	u := url.URL{
 		Scheme: "https",
 		Host:   "porkbun.com",
-		Path:   "/api/json/v3/dns/deleteByNameType/" + p.domain + "/ALIAS/" + subdomain,
+		Path:   "/api/json/v3/dns/deleteByNameType/" + p.domain + "/" + recordType + "/" + subdomain,
 	}
 	postRecordsParams := struct {
 		SecretAPIKey string `json:"secretapikey"`

--- a/internal/provider/providers/porkbun/provider.go
+++ b/internal/provider/providers/porkbun/provider.go
@@ -156,7 +156,7 @@ func (p *Provider) deleteALIASRecordIfNeeded(ctx context.Context, client *http.C
 		return nil
 	}
 
-	err = p.deleteAliasRecord(ctx, client)
+	err = p.deleteRecord(ctx, client, "ALIAS")
 	if err != nil {
 		return fmt.Errorf("deleting ALIAS record: %w", err)
 	}


### PR DESCRIPTION
# Description
This updates the API to allow calling delete on any type. It's currently unused, but more closely matches how the API is documented.

# Test-Plan
Used delete to delete A records and Alias records