### PR TITLE
add Loopia

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This readme and the [docs/](docs/) directory are **versioned** to match the prog
   - INWX
   - Ionos
   - Linode
+  - Loopia
   - LuaDNS
   - Name.com
   - Namecheap
@@ -239,6 +240,7 @@ Check the documentation for your DNS provider:
 - [INWX](docs/inwx.md)
 - [Ionos](docs/ionos.md)
 - [Linode](docs/linode.md)
+- [Loopia](docs/loopia.md)
 - [LuaDNS](docs/luadns.md)
 - [Name.com](docs/name.com.md)
 - [Namecheap](docs/namecheap.md)

--- a/docs/loopia.md
+++ b/docs/loopia.md
@@ -1,0 +1,31 @@
+# Loopia
+
+## Configuration
+
+### Example
+
+```json
+{
+  "settings": [
+    {
+      "provider": "loopia",
+      "domain": "domain.com",
+      "username": "username",
+      "password": "password",
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+### Compulsory parameters
+
+- `"domain"` is the domain to update. It can be `example.com` (root domain), `sub.example.com` (subdomain of `example.com`). It cannot be a wildcard domain.
+- `"username"`
+- `"password"`
+
+### Optional parameters
+
+- `"ip_version"` can be `ipv4` (A records), or `ipv6` (AAAA records) or `ipv4 or ipv6` (update one of the two, depending on the public ip found). It defaults to `ipv4 or ipv6`.
+- `"ipv6_suffix"` is the IPv6 interface identifier suffix to use. It can be for example `0:0:0:0:72ad:8fbb:a54e:bedd/64`. If left empty, it defaults to no suffix and the raw public IPv6 address obtained is used in the record updating.

--- a/internal/provider/constants/providers.go
+++ b/internal/provider/constants/providers.go
@@ -35,6 +35,7 @@ const (
 	INWX         models.Provider = "inwx"
 	Ionos        models.Provider = "ionos"
 	Linode       models.Provider = "linode"
+	Loopia       models.Provider = "loopia"
 	LuaDNS       models.Provider = "luadns"
 	Namecheap    models.Provider = "namecheap"
 	NameCom      models.Provider = "name.com"
@@ -86,6 +87,7 @@ func ProviderChoices() []models.Provider {
 		INWX,
 		Ionos,
 		Linode,
+		Loopia,
 		LuaDNS,
 		Namecheap,
 		NameCom,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,6 +41,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/providers/inwx"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/ionos"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/linode"
+	"github.com/qdm12/ddns-updater/internal/provider/providers/loopia"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/luadns"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/namecheap"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/namecom"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -141,6 +141,8 @@ func New(providerName models.Provider, data json.RawMessage, domain, owner strin
 		return ionos.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Linode:
 		return linode.New(data, domain, owner, ipVersion, ipv6Suffix)
+	case constants.Loopia:
+		return loopia.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.LuaDNS:
 		return luadns.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Namecheap:

--- a/internal/provider/providers/loopia/provider.go
+++ b/internal/provider/providers/loopia/provider.go
@@ -154,10 +154,9 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	switch {
 	case strings.HasPrefix(s, "nohost"):
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrHostnameNotExists)
-	case strings.HasPrefix(s, "badrequest"):
-		return netip.Addr{}, fmt.Errorf("%w", errors.ErrBadRequest)
-	case strings.HasPrefix(s, "911"):
-		// returned for multiple issues, bad ip, bad request formats, etc
+	case strings.HasPrefix(s, "badrequest"),
+		strings.HasPrefix(s, "911"):
+		// 911 is returned for multiple issues: bad ip, bad request formats, etc
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrBadRequest)
 	case strings.HasPrefix(s, "badauth"):
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrAuth)

--- a/internal/provider/providers/loopia/provider.go
+++ b/internal/provider/providers/loopia/provider.go
@@ -163,9 +163,7 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrAuth)
 	case strings.HasPrefix(s, constants.Notfqdn):
 		return netip.Addr{}, fmt.Errorf("%w", errors.Notfqdn)
-	case strings.HasPrefix(s, "good"):
-		return ip, nil
-	case strings.HasPrefix(s, "nochg"):
+	case strings.HasPrefix(s, "good"), strings.HasPrefix(s, "nochg"):
 		return ip, nil
 	default:
 		return netip.Addr{}, fmt.Errorf("%w: %s", errors.ErrUnknownResponse, s)

--- a/internal/provider/providers/loopia/provider.go
+++ b/internal/provider/providers/loopia/provider.go
@@ -1,0 +1,173 @@
+package loopia
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/headers"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+)
+
+type Provider struct {
+	domain     string
+	owner      string
+	ipVersion  ipversion.IPVersion
+	ipv6Suffix netip.Prefix
+	username   string
+	password   string
+}
+
+func New(data json.RawMessage, domain, owner string,
+	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix) (
+	provider *Provider, err error) {
+	var providerSpecificSettings struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	err = json.Unmarshal(data, &providerSpecificSettings)
+	if err != nil {
+		return nil, fmt.Errorf("json decoding provider specific settings: %w", err)
+	}
+
+	err = validateSettings(domain, owner,
+		providerSpecificSettings.Username, providerSpecificSettings.Password)
+	if err != nil {
+		return nil, fmt.Errorf("validating provider specific settings: %w", err)
+	}
+
+	return &Provider{
+		domain:     domain,
+		owner:      owner,
+		ipVersion:  ipVersion,
+		ipv6Suffix: ipv6Suffix,
+		username:   providerSpecificSettings.Username,
+		password:   providerSpecificSettings.Password,
+	}, nil
+}
+
+func validateSettings(domain, owner, username, password string) (err error) {
+	err = utils.CheckDomain(domain)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errors.ErrDomainNotValid, err)
+	}
+
+	switch {
+	// Loopia says it supports wildcards but cannot get it to work
+	case owner == "*":
+		return fmt.Errorf("%w", errors.ErrOwnerWildcard)
+	case username == "":
+		return fmt.Errorf("%w", errors.ErrUsernameNotSet)
+	case password == "":
+		return fmt.Errorf("%w", errors.ErrPasswordNotSet)
+	}
+	return nil
+}
+
+func (p *Provider) String() string {
+	return utils.ToString(p.domain, p.owner, constants.Dyn, p.ipVersion)
+}
+
+func (p *Provider) Domain() string {
+	return p.domain
+}
+
+func (p *Provider) Owner() string {
+	return p.owner
+}
+
+func (p *Provider) IPVersion() ipversion.IPVersion {
+	return p.ipVersion
+}
+
+func (p *Provider) IPv6Suffix() netip.Prefix {
+	return p.ipv6Suffix
+}
+
+func (p *Provider) Proxied() bool {
+	return false
+}
+
+func (p *Provider) BuildDomainName() string {
+	return utils.BuildDomainName(p.owner, p.domain)
+}
+
+func (p *Provider) HTML() models.HTMLRow {
+	return models.HTMLRow{
+		Domain:    fmt.Sprintf("<a href=\"http://%s\">%s</a>", p.BuildDomainName(), p.BuildDomainName()),
+		Owner:     p.Owner(),
+		Provider:  "<a href=\"https://www.loopia.se/\">Loopia</a>",
+		IPVersion: p.ipVersion.String(),
+	}
+}
+
+// Unfortunately api description only available in swedish
+// https://support.loopia.se/wiki/om-dyndns-stodet/
+// Bit of explanation for curl scripting in english is available at
+// https://support.loopia.com/wiki/curl/
+func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Addr) (newIP netip.Addr, err error) {
+	u := url.URL{
+		Scheme: "https",
+		User:   url.UserPassword(p.username, p.password),
+		Host:   "dyndns.loopia.se",
+		Path:   "/",
+	}
+	values := url.Values{}
+	values.Set("hostname", utils.BuildURLQueryHostname(p.owner, p.domain))
+	values.Set("myip", ip.String())
+	u.RawQuery = values.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("creating http request: %w", err)
+	}
+	headers.SetUserAgent(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	defer response.Body.Close()
+
+	// response is simply plain text
+	b, err := io.ReadAll(response.Body)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("reading response body: %w", err)
+	}
+	s := string(b)
+
+	// have only found 200 returned
+	if response.StatusCode != http.StatusOK {
+		return netip.Addr{}, fmt.Errorf("%w: %d: %s",
+			errors.ErrHTTPStatusNotValid, response.StatusCode, utils.ToSingleLine(s))
+	}
+
+	switch {
+	case strings.HasPrefix(s, "nohost"):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrHostnameNotExists)
+	case strings.HasPrefix(s, "badrequest"):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrBadRequest)
+	case strings.HasPrefix(s, "911"):
+		// returned for multiple issues, bad ip, bad request formats, etc
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrBadRequest)
+	case strings.HasPrefix(s, "badauth"):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrAuth)
+	case strings.HasPrefix(s, constants.Notfqdn):
+		return netip.Addr{}, fmt.Errorf("%w", errors.Notfqdn)
+	case strings.HasPrefix(s, "good"):
+		return ip, nil
+	case strings.HasPrefix(s, "nochg"):
+		return ip, nil
+	default:
+		return netip.Addr{}, fmt.Errorf("%w: %s", errors.ErrUnknownResponse, s)
+	}
+}

--- a/internal/provider/providers/loopia/provider.go
+++ b/internal/provider/providers/loopia/provider.go
@@ -152,7 +152,8 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	}
 
 	switch {
-	case strings.HasPrefix(s, "nohost"):
+	case strings.HasPrefix(s, "nohost"),
+		strings.HasPrefix(s, constants.Notfqdn):
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrHostnameNotExists)
 	case strings.HasPrefix(s, "badrequest"),
 		strings.HasPrefix(s, "911"):
@@ -160,8 +161,6 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrBadRequest)
 	case strings.HasPrefix(s, "badauth"):
 		return netip.Addr{}, fmt.Errorf("%w", errors.ErrAuth)
-	case strings.HasPrefix(s, constants.Notfqdn):
-		return netip.Addr{}, fmt.Errorf("%w", errors.Notfqdn)
 	case strings.HasPrefix(s, "good"), strings.HasPrefix(s, "nochg"):
 		return ip, nil
 	default:


### PR DESCRIPTION
Added support for Loopia.se, a swedish provider. 

Unfortunately the documentation is quite terrrible and mostly only available in Swedish. (https://support.loopia.se/wiki/om-dyndns-stodet/)

According to the docs it should support wildcards, but I could not get that to work. It only works in the provider's gui but I cannot make it work. Only getting not fully qualified domain name errors.

Creating records does not seem to work.

IPv6 is not documented and I do not have the means to test it either. 

Tested locally and works for my domains