### PR TITLE
fix(gcp): prevent crash for missing record

### DIFF
--- a/internal/provider/providers/gcp/update.go
+++ b/internal/provider/providers/gcp/update.go
@@ -34,19 +34,19 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 		}
 	}
 
-	for _, rrdata := range recordResourceSet.Rrdatas {
-		if rrdata == ip.String() {
-			// already up to date
-			return ip, nil
-		}
-	}
-
 	if !rrSetFound {
 		err = p.createRRSet(ctx, client, fqdn, recordType, ip)
 		if err != nil {
 			return netip.Addr{}, fmt.Errorf("creating record: %w", err)
 		}
 		return ip, nil
+	}
+
+	for _, rrdata := range recordResourceSet.Rrdatas {
+		if rrdata == ip.String() {
+			// already up to date
+			return ip, nil
+		}
 	}
 
 	err = p.patchRRSet(ctx, client, fqdn, recordType, ip)


### PR DESCRIPTION
Currently if the record is missing from GCP updater will crash with a null pointer at `for _, rrdata := range recordResourceSet.Rrdatas {`

so this moves the case when its null first and prevents the crash