### PR TITLE
Docs for using `ipv6_suffix` to update permanent IPV6 address

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -37,4 +37,6 @@ See [this issue comment for context](https://github.com/qdm12/ddns-updater/issue
 - `"ip_version"` can be `ipv4` (A records), or `ipv6` (AAAA records) or `ipv4 or ipv6` (update one of the two, depending on the public ip found). It defaults to `ipv4 or ipv6`.
 - `"ipv6_suffix"` is the IPv6 interface identifier suffix to use. It can be for example `0:0:0:0:72ad:8fbb:a54e:bedd/64`. If left empty, it defaults to no suffix and the raw public IPv6 address obtained is used in the record updating.
 
+> Note: You could set `"ipv6_suffix"` with your permanent IPV6 address suffix (e.g., `0:0:0:0:72ad:8fbb:a54e:bedd/64` in previous example) to avoid updating the temporary IPV6 address.
+
 Special thanks to @Starttoaster for helping out with the [documentation](https://gist.github.com/Starttoaster/07d568c2a99ad7631dd776688c988326) and testing.


### PR DESCRIPTION
Close #868 

Docs for using `ipv6_suffix` to update permanent IPV6 address instead of temporary IPV6 address.