### PR TITLE
Use `RealIP` middleware

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -47,6 +47,7 @@ func newHandler(ctx context.Context, rootURL string,
 
 	router := chi.NewRouter()
 
+	router.Use(middleware.RealIP)
 	router.Use(middleware.Logger)
 	rootURL = strings.TrimSuffix(rootURL, "/")
 


### PR DESCRIPTION
Fixes logging issues when running behind a reverse proxy.

From the [docs](https://github.com/go-chi/chi?tab=readme-ov-file#core-middlewares):

> RealIP: Sets a http.Request's RemoteAddr to either X-Real-IP or X-Forwarded-For

Without this middleware, running the server behind a reverse proxy will result in every log entry to show the IP address of the proxy instead of the real IP address of the connecting client.