### PR TITLE
Fix lookupIPsResilient waiting forever after max retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /data
+.idea

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -77,6 +77,7 @@ func (s *Service) lookupIPsResilient(ctx context.Context, hostname string, tries
 				results <- result{network: network, ips: ips, err: err}
 				return
 			}
+			results <- result{network: network} // retries exceeded
 		}(lookupCtx, network, results)
 	}
 


### PR DESCRIPTION
In the `lookupIPsResilient` func in `internal/update/service.go`, the goroutine will not send any result back if the maximum retries are exceeded with an error other than "no such host". This causes the lookup to wait forever, in turn preventing updates from happening.

I ran into this while trying to add a new provider, I noticed that the update wasn't being triggered because the code seemed to be waiting forever. As it turns out, the ipv6 lookup returned an error like "no suitable address found", which cause it to retry a couple of times and eventually return without sending a result to the channel.

Unrelated change: I added the `.idea` folder to the `.gitignore`, since I work in Goland. Let me know if that's okay, or if I should remove that.

Thanks in advance!