### PR TITLE
update request for DonDominio

### DIFF
--- a/internal/provider/providers/dondominio/provider.go
+++ b/internal/provider/providers/dondominio/provider.go
@@ -119,11 +119,11 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 		Host:   "dondns.dondominio.com",
 		Path:   "/json/",
 		RawQuery: url.Values{
-			"user":   {p.username},
-			"apikey": {p.key},
-			"host":   {utils.BuildURLQueryHostname(p.owner, p.domain)},
-			"ip":     {ip.String()},
-			"lang":   {"en"},
+			"user":     {p.username},
+			"password": {p.key},
+			"host":     {utils.BuildURLQueryHostname(p.owner, p.domain)},
+			"ip":       {ip.String()},
+			"lang":     {"en"},
 		}.Encode(),
 	}
 


### PR DESCRIPTION
The official documentation for DonDominio is wrong, they tell you to use apiKey for the API key but then below in an example they use "password". password is the right name for the parameter, tested with my own domain.

Fixes issue https://github.com/qdm12/ddns-updater/issues/923

![image](https://github.com/user-attachments/assets/4d03db74-58f1-42a3-8621-b734cfc84fc8)
