### PR TITLE
Update README.md: link to Hetzner docs is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Check the documentation for your DNS provider:
 - [GoDaddy](docs/godaddy.md)
 - [GoIP.de](docs/goip.md)
 - [He.net](docs/he.net.md)
+- [Hetzner](docs/hetzner.md)
 - [Infomaniak](docs/infomaniak.md)
 - [INWX](docs/inwx.md)
 - [Ionos](docs/ionos.md)


### PR DESCRIPTION
Hetzner is mentioned in the list of supported services, but in the list of links to the docs Hetzner is missing.