### PR TITLE
Provider njalla: Update update URI

### DIFF
--- a/internal/provider/providers/njalla/provider.go
+++ b/internal/provider/providers/njalla/provider.go
@@ -103,7 +103,7 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	u := url.URL{
 		Scheme: "https",
 		Host:   "njal.la",
-		Path:   "/update",
+		Path:   "/update/",
 	}
 	values := url.Values{}
 	values.Set("h", utils.BuildURLQueryHostname(p.owner, p.domain))


### PR DESCRIPTION
To prevent a HTTP 301 redirect each request. This URI matches the one on the official documentation at <https://njal.la/docs/ddns/>.