### PR TITLE
fix(ionos): use correct library for joining URL paths to avoid errors…

### DIFF
--- a/internal/provider/providers/ionos/get.go
+++ b/internal/provider/providers/ionos/get.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
@@ -45,7 +45,7 @@ func (p *Provider) get(ctx context.Context, client *http.Client,
 	u := url.URL{
 		Scheme:   "https",
 		Host:     "api.hosting.ionos.com",
-		Path:     filepath.Join("/dns/v1/", subPath),
+		Path:     path.Join("/dns/v1/", subPath),
 		RawQuery: queryParams.Encode(),
 	}
 


### PR DESCRIPTION
… in Windows

Fixes issue #982 

`filepath.Join()` is for filesystem paths, `path.Join()` should be used for URLs instead, as described here: https://github.com/golang/go/issues/30616