### PR TITLE
test(settings): take into account the OS specific file separator

### DIFF
--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -15,7 +15,7 @@ func Test_Settings_String(t *testing.T) {
 
 	s := defaultSettings.String()
 
-	var expected = `Settings summary:
+	expected := `Settings summary:
 ├── HTTP client
 |   └── Timeout: 20s
 ├── Update


### PR DESCRIPTION
Test currently fails on Windows environments:

```
Error:      	Not equal: 
				expected: "Settings summary:\n├── HTTP client\n|   └── Timeout: 20s\n├── Update\n|   ├── Period: 10m0s\n|   └── Cooldown: 5m0s\n├── Public IP fetching\n|   ├── HTTP enabled: yes\n|   ├── HTTP IP providers\n|   |   └── all\n|   ├── HTTP IPv4 providers\n|   |   └── all\n|   ├── HTTP IPv6 providers\n|   |   └── all\n|   ├── DNS enabled: yes\n|   ├── DNS timeout: 3s\n|   └── DNS over TLS providers\n|       └── all\n├── Resolver: use Go default resolver\n├── Server\n|   ├── Listening address: :8000\n|   └── Root URL: /\n├── Health\n|   └── Server is disabled\n├── Paths\n|   ├── Data directory: ./data\n|   ├── Config file: data/config.json\n|   └── Umask: system default\n├── Backup: disabled\n└── Logger\n    ├── Level: INFO\n    └── Caller: hidden"
				actual  : "Settings summary:\n├── HTTP client\n|   └── Timeout: 20s\n├── Update\n|   ├── Period: 10m0s\n|   └── Cooldown: 5m0s\n├── Public IP fetching\n|   ├── HTTP enabled: yes\n|   ├── HTTP IP providers\n|   |   └── all\n|   ├── HTTP IPv4 providers\n|   |   └── all\n|   ├── HTTP IPv6 providers\n|   |   └── all\n|   ├── DNS enabled: yes\n|   ├── DNS timeout: 3s\n|   └── DNS over TLS providers\n|       └── all\n├── Resolver: use Go default resolver\n├── Server\n|   ├── Listening address: :8000\n|   └── Root URL: /\n├── Health\n|   └── Server is disabled\n├── Paths\n|   ├── Data directory: ./data\n|   ├── Config file: data\\config.json\n|   └── Umask: system default\n├── Backup: disabled\n└── Logger\n    ├── Level: INFO\n    └── Caller: hidden"
				
				Diff:
				--- Expected
				+++ Actual
				@@ -26,3 +26,3 @@
					|   ├── Data directory: ./data
				-|   ├── Config file: data/config.json
				+|   ├── Config file: data\config.json
					|   └── Umask: system default
Test:       	Test_Settings_String
```

By dynamically generating the expected filepath we ensure the corresponding OS file separator is used.