### PR TITLE
Bump number of retries before abandoning all polling for a domain

### DIFF
--- a/internal/update/getip.go
+++ b/internal/update/getip.go
@@ -18,7 +18,7 @@ var ErrIPv6NotSupported = errors.New("IPv6 is not supported on this system")
 func tryAndRepeatGettingIP(ctx context.Context, getIPFunc getIPFunc,
 	logger Logger, version ipversion.IPVersion,
 ) (ip netip.Addr, err error) {
-	const tries = 3
+	const tries = 60
 	logMessagePrefix := "obtaining " + version.String() + " address"
 	errs := make([]error, 0, tries)
 	for try := range tries {


### PR DESCRIPTION
This should help weather the storm on brief connection outages. It's a bad and stupid solution, but it's less bad than the existing default.

Closes: https://github.com/qdm12/ddns-updater/issues/1029