### PR TITLE
perf(persistence): replace O(n) linear scans with O(1) index lookups

### DIFF
--- a/internal/persistence/json/database.go
+++ b/internal/persistence/json/database.go
@@ -16,6 +16,21 @@ type Database struct {
 	data     dataModel
 	filepath string
 	mutex    sync.RWMutex
+	// index maps "domain\x00owner" to the record index in data.Records
+	// for O(1) lookups instead of linear scans.
+	index map[string]int
+}
+
+func recordKey(domain, owner string) string {
+	return domain + "\x00" + owner
+}
+
+func buildIndex(records []record) map[string]int {
+	index := make(map[string]int, len(records))
+	for i, r := range records {
+		index[recordKey(r.Domain, r.Owner)] = i
+	}
+	return index
 }
 
 func (db *Database) Close() error {
@@ -38,7 +53,7 @@ func NewDatabase(dataDir string) (*Database, error) {
 		if err != nil {
 			return nil, fmt.Errorf("creating data directory: %w", err)
 		}
-		return &Database{filepath: filePath}, nil
+		return &Database{filepath: filePath, index: make(map[string]int)}, nil
 	}
 
 	stat, err := file.Stat()
@@ -47,7 +62,7 @@ func NewDatabase(dataDir string) (*Database, error) {
 		return nil, fmt.Errorf("stating file: %w", err)
 	} else if stat.Size() == 0 { // empty file
 		_ = file.Close()
-		return &Database{filepath: filePath}, nil
+		return &Database{filepath: filePath, index: make(map[string]int)}, nil
 	}
 
 	decoder := json.NewDecoder(file)
@@ -79,6 +94,7 @@ func NewDatabase(dataDir string) (*Database, error) {
 	return &Database{
 		data:     data,
 		filepath: filePath,
+		index:    buildIndex(data.Records),
 	}, nil
 }
 

--- a/internal/persistence/json/queries.go
+++ b/internal/persistence/json/queries.go
@@ -14,21 +14,15 @@ func (db *Database) StoreNewIP(domain, owner string, ip netip.Addr, t time.Time)
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
 
-	targetIndex := -1
-	for i, record := range db.data.Records {
-		if record.Domain == domain && record.Owner == owner {
-			targetIndex = i
-			break
-		}
-	}
-
-	recordNotFound := targetIndex == -1
-	if recordNotFound {
+	key := recordKey(domain, owner)
+	targetIndex, exists := db.index[key]
+	if !exists {
 		db.data.Records = append(db.data.Records, record{
 			Domain: domain,
 			Owner:  owner,
 		})
 		targetIndex = len(db.data.Records) - 1
+		db.index[key] = targetIndex
 	}
 
 	event := models.HistoryEvent{
@@ -46,10 +40,9 @@ func (db *Database) GetEvents(domain, owner string,
 ) (events []models.HistoryEvent, err error) {
 	db.mutex.RLock()
 	defer db.mutex.RUnlock()
-	for _, record := range db.data.Records {
-		if record.Domain == domain && record.Owner == owner {
-			return filterEvents(record.Events, ipVersion), nil
-		}
+	key := recordKey(domain, owner)
+	if idx, exists := db.index[key]; exists {
+		return filterEvents(db.data.Records[idx].Events, ipVersion), nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

- Adds an in-memory index map (`map[string]int`) to the JSON database, keyed by `"domain\x00owner"`, mapping to the record's slice index
- Replaces linear scans in `StoreNewIP()` and `GetEvents()` with O(1) map lookups
- Index is built at database load time and kept in sync when new records are appended

Fixes #1092

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all existing tests pass
- [ ] Manual: verify IP updates persist correctly with multiple records
- [ ] Manual: verify database loads correctly from existing `updates.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)