### PR TITLE
perf: reuse HTTP client transport instead of cloning it

### DIFF
--- a/internal/update/logclient.go
+++ b/internal/update/logclient.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -16,29 +15,18 @@ type DebugLogger interface {
 	Debug(s string)
 }
 
-func makeLogClient(client *http.Client, logger DebugLogger) (newClient *http.Client) {
-	newClient = &http.Client{
-		Timeout: client.Timeout,
+func makeLogClient(client *http.Client, logger DebugLogger) *http.Client {
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
 	}
 
-	originalTransport := client.Transport
-	if originalTransport == nil {
-		originalTransport = http.DefaultTransport
-	}
-
-	transport, ok := originalTransport.(*http.Transport)
-	if !ok {
-		panic(fmt.Sprintf("transport %T is not *http.Transport", originalTransport))
-	}
-
-	clonedTransport := transport.Clone()
-
-	newClient.Transport = &loggingRoundTripper{
-		proxied: clonedTransport,
+	client.Transport = &loggingRoundTripper{
+		proxied: transport,
 		logger:  logger,
 	}
 
-	return newClient
+	return client
 }
 
 type loggingRoundTripper struct {

--- a/internal/update/logclient_test.go
+++ b/internal/update/logclient_test.go
@@ -104,7 +104,7 @@ func Test_LogClient(t *testing.T) {
 
 			logClient := makeLogClient(client, logger)
 
-			assert.Equal(t, logClient.Timeout, client.Timeout)
+			assert.Same(t, logClient, client)
 
 			ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- `makeLogClient()` was creating a new `http.Client` with `transport.Clone()`, giving it a separate connection pool
- TCP+TLS connections were never reused between update cycles — every cycle paid for new handshakes
- Now wraps the original client's transport with `loggingRoundTripper` directly, preserving the connection pool and keep-alive behavior
- Net effect: **-12 lines**, simpler code, fewer allocations, real network savings

Fixes #1094

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all tests pass including `Test_LogClient`
- [ ] Manual: verify debug logging still works when enabled
- [ ] Manual: verify DNS updates succeed with the shared transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)