### PR TITLE
feat(provider): `vddns.vn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This readme and the [docs/](docs/) directory are **versioned** to match the prog
   - Variomedia.de
   - Vultr
   - Zoneedit
+  - Vddns
   - **Want more?** [Create an issue for it](https://github.com/qdm12/ddns-updater/issues/new/choose)!
 - Web user interface (Desktop)
 

--- a/docs/vddns.md
+++ b/docs/vddns.md
@@ -1,0 +1,33 @@
+# Vddns
+
+## Configuration
+
+### Example
+
+```json
+{
+  "settings": [
+    {
+      "provider": "vddns",
+      "domain": "sub.vddns.vn",
+      "username": "username",
+      "password": "password",
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+### Compulsory parameters
+
+- `"domain"` is the domain to update. It can be `sub.vddns.vn` (subdomain of `vddns.vn`).
+- `"username"`
+- `"password"`
+
+### Optional parameters
+
+- `"ip_version"` can be `ipv4` (A records), or `ipv6` (AAAA records) or `ipv4 or ipv6` (update one of the two, depending on the public ip found). It defaults to `ipv4 or ipv6`.
+- `"ipv6_suffix"` is the IPv6 interface identifier suffix to use. It can be for example `0:0:0:0:72ad:8fbb:a54e:bedd/64`. If left empty, it defaults to no suffix and the raw public IPv6 address obtained is used in the record updating.
+
+## Domain setup

--- a/internal/provider/constants/providers.go
+++ b/internal/provider/constants/providers.go
@@ -54,6 +54,7 @@ const (
 	Spdyn        models.Provider = "spdyn"
 	Strato       models.Provider = "strato"
 	Variomedia   models.Provider = "variomedia"
+	Vddns        models.Provider = "vddns"
 	Vultr        models.Provider = "vultr"
 	Zoneedit     models.Provider = "zoneedit"
 )
@@ -107,6 +108,7 @@ func ProviderChoices() []models.Provider {
 		Spdyn,
 		Strato,
 		Variomedia,
+		Vddns,
 		Vultr,
 		Zoneedit,
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,6 +60,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/providers/spdyn"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/strato"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/variomedia"
+	"github.com/qdm12/ddns-updater/internal/provider/providers/vddns"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/vultr"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/zoneedit"
 	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
@@ -184,6 +185,8 @@ func New(providerName models.Provider, data json.RawMessage, domain, owner strin
 		return strato.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Variomedia:
 		return variomedia.New(data, domain, owner, ipVersion, ipv6Suffix)
+	case constants.Vddns:
+		return vddns.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Vultr:
 		return vultr.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Zoneedit:

--- a/internal/provider/providers/vddns/provider.go
+++ b/internal/provider/providers/vddns/provider.go
@@ -1,0 +1,144 @@
+package vddns
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"net/url"
+
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/headers"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+)
+
+type Provider struct {
+	domain     string
+	owner      string
+	ipVersion  ipversion.IPVersion
+	ipv6Suffix netip.Prefix
+	username   string
+	password   string
+}
+
+func New(data json.RawMessage, domain, owner string,
+	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix) (
+	p *Provider, err error,
+) {
+	var providerSpecificSettings struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	err = json.Unmarshal(data, &providerSpecificSettings)
+	if err != nil {
+		return nil, fmt.Errorf("json decoding provider specific settings: %w", err)
+	}
+
+	err = validateSettings(domain,
+		providerSpecificSettings.Username, providerSpecificSettings.Password)
+	if err != nil {
+		return nil, fmt.Errorf("validating provider specific settings: %w", err)
+	}
+
+	return &Provider{
+		domain:     domain,
+		owner:      owner,
+		ipVersion:  ipVersion,
+		ipv6Suffix: ipv6Suffix,
+		username:   providerSpecificSettings.Username,
+		password:   providerSpecificSettings.Password,
+	}, nil
+}
+
+func validateSettings(domain, username, password string) (err error) {
+	err = utils.CheckDomain(domain)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errors.ErrDomainNotValid, err)
+	}
+
+	switch {
+	case username == "":
+		return fmt.Errorf("%w", errors.ErrUsernameNotSet)
+	case password == "":
+		return fmt.Errorf("%w", errors.ErrPasswordNotSet)
+	}
+	return nil
+}
+
+func (p *Provider) String() string {
+	return utils.ToString(p.domain, p.owner, constants.Vddns, p.ipVersion)
+}
+
+func (p *Provider) Domain() string {
+	return p.domain
+}
+
+func (p *Provider) Owner() string {
+	return p.owner
+}
+
+func (p *Provider) IPVersion() ipversion.IPVersion {
+	return p.ipVersion
+}
+
+func (p *Provider) IPv6Suffix() netip.Prefix {
+	return p.ipv6Suffix
+}
+
+func (p *Provider) Proxied() bool {
+	return false
+}
+
+func (p *Provider) BuildDomainName() string {
+	return utils.BuildDomainName(p.owner, p.domain)
+}
+
+func (p *Provider) HTML() models.HTMLRow {
+	return models.HTMLRow{
+		Domain:    fmt.Sprintf("<a href=\"http://%s\">%s</a>", p.BuildDomainName(), p.BuildDomainName()),
+		Owner:     p.Owner(),
+		Provider:  "<a href=\"http://vddns.vn\">vddns.vn</a>",
+		IPVersion: p.ipVersion.String(),
+	}
+}
+
+func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Addr) (newIP netip.Addr, err error) {
+	u := url.URL{
+		Scheme: "http",
+		Host:   "vddns.vn",
+		Path:   "/nic/update",
+	}
+	values := url.Values{}
+	values.Set("hostname", utils.BuildURLQueryHostname(p.owner, p.domain))
+	values.Set("ip", ip.String())
+	u.RawQuery = values.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("creating http request: %w", err)
+	}
+	request.SetBasicAuth(p.username, p.password)
+	headers.SetUserAgent(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("doing http request: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		defer response.Body.Close()
+		return netip.Addr{}, fmt.Errorf("%w: %d: %s", errors.ErrHTTPStatusNotValid,
+			response.StatusCode, utils.BodyToSingleLine(response.Body))
+	}
+
+	err = response.Body.Close()
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("closing response body: %w", err)
+	}
+
+	return ip, nil
+}


### PR DESCRIPTION
This pull request adds support for the `vddns` DNS provider to the project. The main changes involve registering the new provider, implementing its logic, and integrating it into the provider selection and instantiation flow.

**Provider Integration:**

* Added `Vddns` to the list of available providers in `constants/providers.go` and included it in the provider choices. [[1]](diffhunk://#diff-2d87ba10bce708a4542deaea6ed8cca607da44a6a37cf6ac84f84e0373acba51R57) [[2]](diffhunk://#diff-2d87ba10bce708a4542deaea6ed8cca607da44a6a37cf6ac84f84e0373acba51R111)
* Registered the new provider in the provider factory method in `provider.go`, enabling instantiation based on user configuration.
* Imported the new provider implementation in the provider registry.

**Provider Implementation:**

* Created a new file `providers/vddns/provider.go` implementing the `vddns` provider logic, including configuration validation, update requests to the provider's API, and integration with the existing provider interface.