### PR TITLE
fix: add proportional jitter to reduce synchronized API calls

### DIFF
--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -413,6 +414,7 @@ func (s *Service) run(ctx context.Context, ready chan<- struct{},
 	for {
 		select {
 		case <-ticker.C:
+			time.Sleep(jitterDuration(s.period))
 			s.updateNecessary(ctx)
 		case <-s.force:
 			s.forceResult <- s.updateNecessary(ctx)
@@ -438,4 +440,13 @@ func (s *Service) ForceUpdate(ctx context.Context) (errs []error) {
 		errs = []error{ctx.Err()}
 	}
 	return errs
+}
+
+// jitterDuration returns a random duration in [0, period/5) to spread
+// update calls and avoid synchronized API traffic spikes.
+func jitterDuration(period time.Duration) time.Duration {
+	if divisor := int64(period) / 5; divisor > 0 {
+		return time.Duration(rand.Int63n(divisor))
+	}
+	return 0
 }

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -1,0 +1,36 @@
+package update
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJitterDuration(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		period   time.Duration
+		wantZero bool
+		wantMax  time.Duration
+	}{
+		{"5m interval", 5 * time.Minute, false, 60 * time.Second},
+		{"1h interval", time.Hour, false, 12 * time.Minute},
+		{"4ns sub-threshold", 4 * time.Nanosecond, true, 0},
+		{"zero", 0, true, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := jitterDuration(tc.period)
+			if tc.wantZero {
+				if got != 0 {
+					t.Errorf("want 0, got %v", got)
+				}
+				return
+			}
+			if got < 0 || got > tc.wantMax {
+				t.Errorf("want [0, %v], got %v", tc.wantMax, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello, I'm a product manager at @Cloudflare who oversees our API platform. Our logs show that we get millions of clients calling our DDNS endpoints every 5 minutes. This is a noticeable increase over our typical baseline, and contributes to performance degradation. We would like to smooth out the API traffic so that the spikes aren't so prominent, and we have identified your project as one to reach out to.

I added some code that introduces proportional jitter to the DDNS update interval, which should help reduce synchronized API calls and improve performance for us and all the other services that you're using.

Let me know if you have any questions on this, happy to take your suggestions on this as well!