### PR TITLE
fix(provider): fix typo in hetznercloud action status check

### DIFF
--- a/internal/provider/providers/hetznercloud/common.go
+++ b/internal/provider/providers/hetznercloud/common.go
@@ -23,7 +23,7 @@ func (p *Provider) handleActionResponse(ctx context.Context, client *http.Client
 	switch parsed.Action.Status {
 	case "success":
 		return nil
-	case "running:":
+	case "running":
 		err = p.waitAction(ctx, client, parsed.Action.ID)
 		if err != nil {
 			return fmt.Errorf("waiting for action to complete: %w", err)


### PR DESCRIPTION
Fixes a typo when handling the "running" action status, producing this error:
```
2026-04-27T18:47:11Z ERROR updating record: handling action response: unknown response received: unexpected action status "running" for action id 626463938761322
```