### PR TITLE
Use correct provider name in Scaleway String()

### DIFF
--- a/internal/provider/providers/scaleway/provider.go
+++ b/internal/provider/providers/scaleway/provider.go
@@ -69,7 +69,7 @@ func validateSettings(domain, secretKey string) (err error) {
 }
 
 func (p *Provider) String() string {
-	return utils.ToString(p.domain, p.owner, constants.Dyn, p.ipVersion)
+	return utils.ToString(p.domain, p.owner, constants.Scaleway, p.ipVersion)
 }
 
 func (p *Provider) Domain() string {


### PR DESCRIPTION
The `String()` function in the new Scaleway provider incorrectly references the `dyn` provider, so this commit updates it to the correct constant.