### PR TITLE
fix(hetznercloud): poll zone action endpoint with adequate timeout

### DIFF
--- a/internal/provider/providers/hetznercloud/provider.go
+++ b/internal/provider/providers/hetznercloud/provider.go
@@ -15,9 +15,8 @@ import (
 	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
 )
 
-// defaultActionPollPeriod is the interval between two Zone action status polls.
-// Combined with the number of tries in waitAction, it defines the total time
-// spent waiting for an asynchronous Zone action to complete.
+// defaultActionPollPeriod is the interval between two Zone action status polls
+// in waitAction.
 const defaultActionPollPeriod = 5 * time.Second
 
 type Provider struct {
@@ -31,7 +30,6 @@ type Provider struct {
 	// See https://docs.hetzner.cloud/reference/cloud#tag/zone-rrset-actions/add_zone_rrset_records.body.ttl
 	ttl uint32
 	// actionPollPeriod is the interval between two Zone action status polls.
-	// See waitAction.
 	actionPollPeriod time.Duration
 }
 

--- a/internal/provider/providers/hetznercloud/provider.go
+++ b/internal/provider/providers/hetznercloud/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"time"
 
 	"github.com/qdm12/ddns-updater/internal/models"
 	"github.com/qdm12/ddns-updater/internal/provider/constants"
@@ -13,6 +14,10 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/utils"
 	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
 )
+
+// defaultActionPollPeriod is the interval between two Zone action status
+// polls in waitAction.
+const defaultActionPollPeriod = 5 * time.Second
 
 type Provider struct {
 	domain     string
@@ -24,6 +29,10 @@ type Provider struct {
 	// It is optional, and is ONLY used to add a record to the rrset.
 	// See https://docs.hetzner.cloud/reference/cloud#tag/zone-rrset-actions/add_zone_rrset_records.body.ttl
 	ttl uint32
+	// actionPollPeriod is the interval between two Zone action status polls.
+	// It defaults to defaultActionPollPeriod and is only set to a shorter
+	// period in tests.
+	actionPollPeriod time.Duration
 }
 
 func New(data json.RawMessage, domain, owner string,
@@ -45,12 +54,13 @@ func New(data json.RawMessage, domain, owner string,
 	}
 
 	return &Provider{
-		domain:     domain,
-		owner:      owner,
-		ipVersion:  ipVersion,
-		ipv6Suffix: ipv6Suffix,
-		token:      extraSettings.Token,
-		ttl:        extraSettings.TTL,
+		domain:           domain,
+		owner:            owner,
+		ipVersion:        ipVersion,
+		ipv6Suffix:       ipv6Suffix,
+		token:            extraSettings.Token,
+		ttl:              extraSettings.TTL,
+		actionPollPeriod: defaultActionPollPeriod,
 	}, nil
 }
 

--- a/internal/provider/providers/hetznercloud/provider.go
+++ b/internal/provider/providers/hetznercloud/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"time"
 
 	"github.com/qdm12/ddns-updater/internal/models"
 	"github.com/qdm12/ddns-updater/internal/provider/constants"
@@ -13,6 +14,11 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/utils"
 	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
 )
+
+// defaultActionPollPeriod is the interval between two Zone action status polls.
+// Combined with the number of tries in waitAction, it defines the total time
+// spent waiting for an asynchronous Zone action to complete.
+const defaultActionPollPeriod = 5 * time.Second
 
 type Provider struct {
 	domain     string
@@ -24,6 +30,9 @@ type Provider struct {
 	// It is optional, and is ONLY used to add a record to the rrset.
 	// See https://docs.hetzner.cloud/reference/cloud#tag/zone-rrset-actions/add_zone_rrset_records.body.ttl
 	ttl uint32
+	// actionPollPeriod is the interval between two Zone action status polls.
+	// See waitAction.
+	actionPollPeriod time.Duration
 }
 
 func New(data json.RawMessage, domain, owner string,
@@ -45,12 +54,13 @@ func New(data json.RawMessage, domain, owner string,
 	}
 
 	return &Provider{
-		domain:     domain,
-		owner:      owner,
-		ipVersion:  ipVersion,
-		ipv6Suffix: ipv6Suffix,
-		token:      extraSettings.Token,
-		ttl:        extraSettings.TTL,
+		domain:           domain,
+		owner:            owner,
+		ipVersion:        ipVersion,
+		ipv6Suffix:       ipv6Suffix,
+		token:            extraSettings.Token,
+		ttl:              extraSettings.TTL,
+		actionPollPeriod: defaultActionPollPeriod,
 	}, nil
 }
 

--- a/internal/provider/providers/hetznercloud/update_wildcard_test.go
+++ b/internal/provider/providers/hetznercloud/update_wildcard_test.go
@@ -1,7 +1,6 @@
 package hetznercloud
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,7 +38,7 @@ func (rt *recordingTransport) RoundTrip(request *http.Request) (*http.Response, 
 		}, nil
 	}
 	return &http.Response{
-		StatusCode: response.statusCode,
+		StatusCode: int(response.statusCode),
 		Body:       io.NopCloser(strings.NewReader(response.body)),
 	}, nil
 }
@@ -60,7 +59,7 @@ func Test_Provider_Update_wildcard(t *testing.T) {
 		domain   = "example.com"
 		actionID = 12345
 	)
-	newIP := netip.MustParseAddr("185.28.78.5")
+	newIP := netip.AddrFrom4([4]byte{185, 28, 78, 5})
 
 	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
 	successBody := fmt.Sprintf(`{"action":{"id":%d,"status":"success"}}`, actionID)
@@ -126,7 +125,7 @@ func Test_Provider_Update_wildcard(t *testing.T) {
 				actionPollPeriod: time.Millisecond,
 			}
 
-			gotIP, err := provider.Update(context.Background(), client, newIP)
+			gotIP, err := provider.Update(t.Context(), client, newIP)
 			require.NoError(t, err)
 			assert.Equal(t, newIP, gotIP)
 

--- a/internal/provider/providers/hetznercloud/update_wildcard_test.go
+++ b/internal/provider/providers/hetznercloud/update_wildcard_test.go
@@ -1,0 +1,148 @@
+package hetznercloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testToken is a dummy API token used across the hetznercloud provider tests.
+const testToken = "token"
+
+// recordingTransport records every request URL it sees and returns canned
+// responses keyed by "METHOD PATH". This lets us assert how the wildcard
+// owner "*" is turned into request URLs.
+type recordingTransport struct {
+	t         *testing.T
+	responses map[string]bodyResponse
+	gotURLs   []string
+}
+
+func (rt *recordingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	rt.gotURLs = append(rt.gotURLs, request.URL.String())
+	key := request.Method + " " + request.URL.Path
+	response, ok := rt.responses[key]
+	if !ok {
+		rt.t.Errorf("unexpected request %s", key)
+		return &http.Response{
+			StatusCode: http.StatusNotImplemented,
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: response.statusCode,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+	}, nil
+}
+
+// Test_Provider_Update_wildcard is a regression test for the wildcard
+// rapid-update loop reported in
+// https://github.com/qdm12/ddns-updater/issues/1039 (comment by Daxolion).
+//
+// A wildcard owner "*" must be treated like any other owner: the "*" has to
+// appear literally in the rrset path (the Hetzner Cloud API returns 404 for
+// the percent-encoded "%2A"), and the asynchronous zone action returned by the
+// write must be polled on the zone actions endpoint. Getting either wrong made
+// the provider believe the update failed and retry it on every cycle.
+func Test_Provider_Update_wildcard(t *testing.T) {
+	t.Parallel()
+
+	const (
+		domain   = "example.com"
+		actionID = 12345
+	)
+	newIP := netip.MustParseAddr("185.28.78.5")
+
+	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
+	successBody := fmt.Sprintf(`{"action":{"id":%d,"status":"success"}}`, actionID)
+	createdActionBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"},`+
+		`"rrset":{"id":"*/A","name":"*","type":"A"}}`, actionID)
+
+	rrsetPath := "/v1/zones/" + domain + "/rrsets"
+	wildcardRRSetPath := rrsetPath + "/*/A"
+	zoneActionPath := fmt.Sprintf("/v1/zones/actions/%d", actionID)
+	serverActionPath := fmt.Sprintf("/v1/servers/actions/%d", actionID)
+
+	testCases := map[string]struct {
+		responses map[string]bodyResponse
+		// wantURLs are URLs that must have been requested.
+		wantURLs []string
+	}{
+		// The record does not exist yet: getRecord returns 404, so the provider
+		// creates the rrset and then polls the resulting zone action.
+		"create": {
+			responses: map[string]bodyResponse{
+				"GET " + wildcardRRSetPath: {http.StatusNotFound, `{"error":{"code":"not_found"}}`},
+				"POST " + rrsetPath:        {http.StatusCreated, createdActionBody},
+				"GET " + zoneActionPath:    {http.StatusOK, successBody},
+			},
+			wantURLs: []string{
+				"https://api.hetzner.cloud" + wildcardRRSetPath,
+				"https://api.hetzner.cloud" + rrsetPath,
+				"https://api.hetzner.cloud" + zoneActionPath,
+			},
+		},
+		// The record exists with a different IP: getRecord returns 200 and a
+		// stale value, so the provider replaces it via set_records and then
+		// polls the resulting zone action.
+		"set_records": {
+			responses: map[string]bodyResponse{
+				"GET " + wildcardRRSetPath: {
+					http.StatusOK,
+					`{"rrset":{"records":[{"value":"192.0.2.1"}]}}`,
+				},
+				"POST " + wildcardRRSetPath + "/actions/set_records": {http.StatusCreated, runningBody},
+				"GET " + zoneActionPath:                              {http.StatusOK, successBody},
+			},
+			wantURLs: []string{
+				"https://api.hetzner.cloud" + wildcardRRSetPath,
+				"https://api.hetzner.cloud" + wildcardRRSetPath + "/actions/set_records",
+				"https://api.hetzner.cloud" + zoneActionPath,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := &recordingTransport{t: t, responses: testCase.responses}
+			client := &http.Client{Transport: transport}
+
+			provider := &Provider{
+				domain:           domain,
+				owner:            "*",
+				ipVersion:        ipversion.IP4,
+				token:            testToken,
+				actionPollPeriod: time.Millisecond,
+			}
+
+			gotIP, err := provider.Update(context.Background(), client, newIP)
+			require.NoError(t, err)
+			assert.Equal(t, newIP, gotIP)
+
+			for _, wantURL := range testCase.wantURLs {
+				assert.Contains(t, transport.gotURLs, wantURL)
+			}
+
+			joinedURLs := strings.Join(transport.gotURLs, "\n")
+			// The wildcard must never be percent-encoded: the Hetzner Cloud API
+			// returns 404 for "%2A".
+			assert.NotContains(t, joinedURLs, "%2A")
+			assert.NotContains(t, joinedURLs, "%2a")
+			// The zone action must never be polled on the server actions
+			// endpoint (regression from issue #1136, which manifested as the
+			// wildcard rapid-update loop in issue #1039).
+			assert.NotContains(t, joinedURLs, serverActionPath)
+		})
+	}
+}

--- a/internal/provider/providers/hetznercloud/update_wildcard_test.go
+++ b/internal/provider/providers/hetznercloud/update_wildcard_test.go
@@ -1,0 +1,128 @@
+package hetznercloud
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_Provider_Update_wildcardOwner is a regression test for the wildcard
+// rapid update loop reported in
+// https://github.com/qdm12/ddns-updater/issues/1039
+//
+// A wildcard owner "*" is handled like any other owner: the "*" appears
+// literally in the rrset path, since the Hetzner Cloud API returns 404 for the
+// percent encoded "%2A", and the asynchronous Zone action returned by the write
+// is polled on the Zone actions endpoint. Getting either of these wrong made
+// the provider consider the update failed and retry it on every cycle.
+func Test_Provider_Update_wildcardOwner(t *testing.T) {
+	t.Parallel()
+
+	const (
+		domain   = "example.com"
+		actionID = 42
+	)
+	newIP := netip.AddrFrom4([4]byte{185, 28, 78, 5})
+
+	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
+	successBody := fmt.Sprintf(`{"action":{"id":%d,"status":"success"}}`, actionID)
+	createdBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"},`+
+		`"rrset":{"id":"*/A","name":"*","type":"A"}}`, actionID)
+	staleRecordBody := `{"rrset":{"records":[{"value":"192.0.2.1"}]}}`
+	notFoundBody := `{"error":{"code":"not_found","message":"rrset not found"}}`
+
+	rrsetsPath := "/v1/zones/" + domain + "/rrsets"
+	wildcardPath := rrsetsPath + "/*/A"
+	setRecordsPath := wildcardPath + "/actions/set_records"
+	zoneActionPath := fmt.Sprintf("/v1/zones/actions/%d", actionID)
+	serverActionPath := fmt.Sprintf("/v1/servers/actions/%d", actionID)
+
+	testCases := map[string]struct {
+		// responses is keyed by "METHOD PATH".
+		responses map[string]bodyResponse
+		// wantRequests are the "METHOD PATH" keys expected, in order.
+		wantRequests []string
+	}{
+		// The rrset does not exist yet, so getRecord gets a 404 and the
+		// provider creates the rrset before polling the resulting Zone action.
+		"create": {
+			responses: map[string]bodyResponse{
+				"GET " + wildcardPath:   {http.StatusNotFound, notFoundBody},
+				"POST " + rrsetsPath:    {http.StatusCreated, createdBody},
+				"GET " + zoneActionPath: {http.StatusOK, successBody},
+			},
+			wantRequests: []string{
+				"GET " + wildcardPath,
+				"POST " + rrsetsPath,
+				"GET " + zoneActionPath,
+			},
+		},
+		// The rrset exists with a stale IP address, so the provider replaces it
+		// with set_records before polling the resulting Zone action.
+		"set_records": {
+			responses: map[string]bodyResponse{
+				"GET " + wildcardPath:    {http.StatusOK, staleRecordBody},
+				"POST " + setRecordsPath: {http.StatusCreated, runningBody},
+				"GET " + zoneActionPath:  {http.StatusOK, successBody},
+			},
+			wantRequests: []string{
+				"GET " + wildcardPath,
+				"POST " + setRecordsPath,
+				"GET " + zoneActionPath,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotRequests, gotRequestURIs []string
+			client := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+				key := r.Method + " " + r.URL.Path
+				gotRequests = append(gotRequests, key)
+				gotRequestURIs = append(gotRequestURIs, r.RequestURI)
+				response, ok := testCase.responses[key]
+				if !ok {
+					t.Errorf("unexpected request %s", key)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(response.statusCode)
+				_, _ = io.WriteString(w, response.body)
+			})
+
+			provider := &Provider{
+				domain:    domain,
+				owner:     "*",
+				ipVersion: ipversion.IP4,
+				token:     testToken,
+				// The poll period is shortened to keep the test fast.
+				actionPollPeriod: time.Millisecond,
+			}
+
+			gotIP, err := provider.Update(t.Context(), client, newIP)
+
+			require.NoError(t, err)
+			assert.Equal(t, newIP, gotIP)
+			assert.Equal(t, testCase.wantRequests, gotRequests)
+
+			joinedRequestURIs := strings.Join(gotRequestURIs, "\n")
+			// The wildcard must not be percent encoded, since the Hetzner
+			// Cloud API returns 404 for "%2A".
+			assert.NotContains(t, joinedRequestURIs, "%2A")
+			assert.NotContains(t, joinedRequestURIs, "%2a")
+			// The Zone action must not be polled on the Server actions
+			// endpoint, which is what issue #1136 was about.
+			assert.NotContains(t, joinedRequestURIs, serverActionPath)
+		})
+	}
+}

--- a/internal/provider/providers/hetznercloud/waitaction.go
+++ b/internal/provider/providers/hetznercloud/waitaction.go
@@ -10,15 +10,24 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
 )
 
+// waitAction polls a Zone action until it completes.
+// The action is returned by Zone RRSet operations such as set_records, so it
+// must be queried through the Zone actions endpoint and NOT the Server actions
+// endpoint, otherwise the lookup returns 404 (action not found).
+// See https://docs.hetzner.cloud/reference/cloud#zone-actions-get-an-action
 func (p *Provider) waitAction(ctx context.Context, client *http.Client, id uint64) (err error) {
 	if id == 0 {
 		return fmt.Errorf("%w: action id is zero", errors.ErrReceivedNoResult)
 	}
 
-	const sleepDuration = time.Second
-	const tries = 3
+	// Zone actions (e.g. set_rrset_records) are processed asynchronously by
+	// Hetzner and observed to take around 20 seconds to reach the success
+	// status, so poll up to 12 times waiting p.actionPollPeriod (5 seconds by
+	// default) between attempts, for up to 60 seconds in total.
+	const tries = 12
+	sleepDuration := p.actionPollPeriod
 	for range tries {
-		url := fmt.Sprintf("https://api.hetzner.cloud/v1/servers/actions/%d", id)
+		url := fmt.Sprintf("https://api.hetzner.cloud/v1/zones/actions/%d", id)
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return fmt.Errorf("creating http request: %w", err)

--- a/internal/provider/providers/hetznercloud/waitaction.go
+++ b/internal/provider/providers/hetznercloud/waitaction.go
@@ -11,19 +11,17 @@ import (
 )
 
 // waitAction polls a Zone action until it completes.
-// The action is returned by Zone RRSet operations such as set_records, so it
-// must be queried through the Zone actions endpoint and NOT the Server actions
-// endpoint, otherwise the lookup returns 404 (action not found).
+// Zone RRSet operations such as set_records return an action belonging to the
+// zone resource, which is queried through the Zone actions endpoint.
 // See https://docs.hetzner.cloud/reference/cloud#zone-actions-get-an-action
 func (p *Provider) waitAction(ctx context.Context, client *http.Client, id uint64) (err error) {
 	if id == 0 {
 		return fmt.Errorf("%w: action id is zero", errors.ErrReceivedNoResult)
 	}
 
-	// Zone actions (e.g. set_rrset_records) are processed asynchronously by
-	// Hetzner and observed to take around 20 seconds to reach the success
-	// status, so poll up to 12 times waiting p.actionPollPeriod (5 seconds by
-	// default) between attempts, for up to 60 seconds in total.
+	// Zone actions take around 20 seconds to reach the success status, so poll
+	// up to 12 times, waiting p.actionPollPeriod between attempts (60s total
+	// with the default period).
 	const tries = 12
 	sleepDuration := p.actionPollPeriod
 	for range tries {

--- a/internal/provider/providers/hetznercloud/waitaction.go
+++ b/internal/provider/providers/hetznercloud/waitaction.go
@@ -13,7 +13,7 @@ import (
 // waitAction polls a Zone action until it completes.
 // Zone RRSet operations such as set_records return an action belonging to the
 // zone resource, which is queried through the Zone actions endpoint.
-// See https://docs.hetzner.cloud/reference/cloud#zone-actions-get-an-action
+// See https://docs.hetzner.cloud/reference/cloud#tag/zone-actions/get_zone_action
 func (p *Provider) waitAction(ctx context.Context, client *http.Client, id uint64) (err error) {
 	if id == 0 {
 		return fmt.Errorf("%w: action id is zero", errors.ErrReceivedNoResult)

--- a/internal/provider/providers/hetznercloud/waitaction.go
+++ b/internal/provider/providers/hetznercloud/waitaction.go
@@ -10,13 +10,20 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
 )
 
+// waitAction polls a Zone action until it reaches a final status.
+// See https://docs.hetzner.cloud/reference/cloud#tag/zone-actions/get_zone_action
 func (p *Provider) waitAction(ctx context.Context, client *http.Client, id uint64) (err error) {
 	if id == 0 {
 		return fmt.Errorf("%w: action id is zero", errors.ErrReceivedNoResult)
 	}
 
-	const sleepDuration = time.Second
-	const tries = 3
+	// Zone actions take around 20 seconds to reach the success status, so poll
+	// up to 12 times, which is a 60 seconds budget with the default period.
+	const tries = 12
+	sleepDuration := p.actionPollPeriod
+	if sleepDuration == 0 {
+		sleepDuration = defaultActionPollPeriod
+	}
 	for range tries {
 		url := fmt.Sprintf("https://api.hetzner.cloud/v1/zones/actions/%d", id)
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -106,7 +106,7 @@ func Test_Provider_waitAction(t *testing.T) {
 			}
 
 			// Use a tiny poll period to keep the test fast.
-			provider := &Provider{token: "token", actionPollPeriod: time.Millisecond}
+			provider := &Provider{token: testToken, actionPollPeriod: time.Millisecond}
 			err := provider.waitAction(context.Background(), client, testCase.id)
 
 			assert.Equal(t, testCase.wantQueries, queries)
@@ -150,7 +150,7 @@ func Test_Provider_waitAction_timeout(t *testing.T) {
 		}),
 	}
 
-	provider := &Provider{token: "token", actionPollPeriod: time.Millisecond}
+	provider := &Provider{token: testToken, actionPollPeriod: time.Millisecond}
 	err := provider.waitAction(context.Background(), client, actionID)
 
 	require.Error(t, err)

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -75,15 +75,19 @@ func Test_Provider_waitAction(t *testing.T) {
 			errWrapped:   errors.ErrHTTPStatusNotValid,
 			errSubstring: "404",
 		},
+		// The Hetzner Cloud API returns the action error as an object
+		// {"code": ..., "message": ...}, not a bare string.
+		// See https://docs.hetzner.cloud/reference/cloud#tag/zone-actions/get_zone_action
 		"action_error": {
 			id: actionID,
 			responses: []bodyResponse{{
 				http.StatusOK,
-				fmt.Sprintf(`{"action":{"id":%d,"status":"error","error":"boom"}}`, actionID),
+				fmt.Sprintf(`{"action":{"id":%d,"status":"error",`+
+					`"error":{"code":"action_failed","message":"Action failed"}}}`, actionID),
 			}},
 			wantQueries:  1,
 			errWrapped:   errors.ErrUnsuccessful,
-			errSubstring: "boom",
+			errSubstring: "action_failed",
 		},
 	}
 

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -2,11 +2,13 @@ package hetznercloud
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qdm12/ddns-updater/internal/provider/errors"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,30 @@ func (t rewriteTransport) RoundTrip(request *http.Request) (*http.Response, erro
 	request.URL.Scheme = "http"
 	request.URL.Host = t.host
 	return t.base.RoundTrip(request)
+}
+
+// testToken is a dummy API token used by the hetznercloud provider tests.
+const testToken = "token"
+
+// bodyResponse is a single HTTP response served by the test API, in the order
+// the requests come in.
+type bodyResponse struct {
+	statusCode int
+	body       string
+}
+
+// newTestAPIClient returns an HTTP client sending every request aimed at
+// api.hetzner.cloud to the given handler.
+func newTestAPIClient(t *testing.T, handler http.HandlerFunc) (client *http.Client) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return &http.Client{Transport: rewriteTransport{
+		host: strings.TrimPrefix(server.URL, "http://"),
+		base: http.DefaultTransport,
+	}}
 }
 
 func Test_waitAction(t *testing.T) {
@@ -84,4 +110,111 @@ func Test_waitAction(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_waitAction_polling(t *testing.T) {
+	t.Parallel()
+
+	const actionID = 42
+	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
+	successBody := fmt.Sprintf(`{"action":{"id":%d,"status":"success"}}`, actionID)
+
+	testCases := map[string]struct {
+		actionID    uint64
+		responses   []bodyResponse
+		wantQueries uint
+		errWrapped  error
+		errMessage  string
+	}{
+		"zero_action_id": {
+			actionID:   0,
+			errWrapped: errors.ErrReceivedNoResult,
+		},
+		// A Zone action is asynchronous and takes around 20 seconds to reach
+		// the success status, so a running status must be polled instead of
+		// being given up on.
+		"running_until_success": {
+			actionID: actionID,
+			responses: []bodyResponse{
+				{http.StatusOK, runningBody},
+				{http.StatusOK, runningBody},
+				{http.StatusOK, successBody},
+			},
+			wantQueries: 3,
+		},
+		// A 404 on the action lookup must be reported instead of being polled
+		// again, since the action id will not appear later.
+		"not_found": {
+			actionID: actionID,
+			responses: []bodyResponse{{
+				http.StatusNotFound,
+				`{"error":{"code":"not_found","message":"action not found"}}`,
+			}},
+			wantQueries: 1,
+			errWrapped:  errors.ErrHTTPStatusNotValid,
+			errMessage:  "404",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var queries uint
+			remaining := testCase.responses
+			client := newTestAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+				if len(remaining) == 0 {
+					t.Errorf("unexpected request number %d", queries+1)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				response := remaining[0]
+				remaining = remaining[1:]
+				queries++
+				w.WriteHeader(response.statusCode)
+				_, _ = io.WriteString(w, response.body)
+			})
+
+			// The poll period is shortened to keep the test fast.
+			provider := &Provider{token: testToken, actionPollPeriod: time.Millisecond}
+
+			err := provider.waitAction(t.Context(), client, testCase.actionID)
+
+			assert.Equal(t, testCase.wantQueries, queries)
+			if testCase.errWrapped != nil {
+				require.ErrorIs(t, err, testCase.errWrapped)
+				if testCase.errMessage != "" {
+					assert.Contains(t, err.Error(), testCase.errMessage)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test_waitAction_timeout checks waitAction gives up with an error once the
+// Zone action did not reach a final status within the allotted tries.
+func Test_waitAction_timeout(t *testing.T) {
+	t.Parallel()
+
+	const actionID = 42
+	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
+
+	var queries uint
+	client := newTestAPIClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		queries++
+		_, _ = io.WriteString(w, runningBody)
+	})
+
+	// The poll period is shortened to keep the test fast.
+	provider := &Provider{token: testToken, actionPollPeriod: time.Millisecond}
+
+	err := provider.waitAction(t.Context(), client, actionID)
+
+	require.ErrorIs(t, err, errors.ErrUnsuccessful)
+	assert.Contains(t, err.Error(), "did not complete")
+	// The action is polled exactly the maximum number of tries.
+	const wantQueries uint = 12
+	assert.Equal(t, wantQueries, queries)
 }

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -1,0 +1,161 @@
+package hetznercloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roundTripFunc lets us mock the HTTP client transport.
+type roundTripFunc func(request *http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request), nil
+}
+
+// bodyResponse describes a single HTTP response returned by the mock transport.
+type bodyResponse struct {
+	statusCode int
+	body       string
+}
+
+func Test_Provider_waitAction(t *testing.T) {
+	t.Parallel()
+
+	const actionID = 12345
+	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
+	successBody := fmt.Sprintf(`{"action":{"id":%d,"status":"success"}}`, actionID)
+
+	testCases := map[string]struct {
+		id           uint64
+		responses    []bodyResponse
+		wantQueries  int
+		errWrapped   error
+		errSubstring string
+	}{
+		"zero_id": {
+			id:         0,
+			errWrapped: errors.ErrReceivedNoResult,
+		},
+		"action_success": {
+			id:          actionID,
+			responses:   []bodyResponse{{http.StatusOK, successBody}},
+			wantQueries: 1,
+		},
+		// The action is asynchronous, so a "running" status must be polled until
+		// it reaches "success".
+		"running_then_success": {
+			id: actionID,
+			responses: []bodyResponse{
+				{http.StatusOK, runningBody},
+				{http.StatusOK, runningBody},
+				{http.StatusOK, successBody},
+			},
+			wantQueries: 3,
+		},
+		// Regression test for https://github.com/qdm12/ddns-updater/issues/1136:
+		// the action originates from a Zone RRSet operation, so querying the
+		// Server actions endpoint returned 404 (action not found) and wrongly
+		// marked successful updates as failed.
+		"not_found_on_action_lookup": {
+			id: actionID,
+			responses: []bodyResponse{{
+				http.StatusNotFound,
+				`{"error":{"code":"not_found","message":"action not found"}}`,
+			}},
+			wantQueries:  1,
+			errWrapped:   errors.ErrHTTPStatusNotValid,
+			errSubstring: "404",
+		},
+		"action_error": {
+			id: actionID,
+			responses: []bodyResponse{{
+				http.StatusOK,
+				fmt.Sprintf(`{"action":{"id":%d,"status":"error","error":"boom"}}`, actionID),
+			}},
+			wantQueries:  1,
+			errWrapped:   errors.ErrUnsuccessful,
+			errSubstring: "boom",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var queries int
+			var lastURL string
+			client := &http.Client{
+				Transport: roundTripFunc(func(request *http.Request) *http.Response {
+					lastURL = request.URL.String()
+					response := testCase.responses[queries]
+					queries++
+					return &http.Response{
+						StatusCode: response.statusCode,
+						Body:       io.NopCloser(strings.NewReader(response.body)),
+					}
+				}),
+			}
+
+			// Use a tiny poll period to keep the test fast.
+			provider := &Provider{token: "token", actionPollPeriod: time.Millisecond}
+			err := provider.waitAction(context.Background(), client, testCase.id)
+
+			assert.Equal(t, testCase.wantQueries, queries)
+			if testCase.wantQueries > 0 {
+				// The action must be queried through the Zone actions endpoint,
+				// not the Server actions endpoint (issue #1136).
+				assert.Equal(t,
+					fmt.Sprintf("https://api.hetzner.cloud/v1/zones/actions/%d", actionID),
+					lastURL)
+			}
+
+			if testCase.errWrapped != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, testCase.errWrapped)
+				if testCase.errSubstring != "" {
+					assert.Contains(t, err.Error(), testCase.errSubstring)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test_Provider_waitAction_timeout ensures waitAction gives up with an error
+// once the action did not complete within the allotted number of tries.
+func Test_Provider_waitAction_timeout(t *testing.T) {
+	t.Parallel()
+
+	const actionID = 12345
+	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
+
+	var queries int
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) *http.Response {
+			queries++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(runningBody)),
+			}
+		}),
+	}
+
+	provider := &Provider{token: "token", actionPollPeriod: time.Millisecond}
+	err := provider.waitAction(context.Background(), client, actionID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errors.ErrUnsuccessful)
+	assert.Contains(t, err.Error(), "did not complete")
+	// The action is polled exactly the maximum number of tries.
+	assert.Equal(t, 12, queries)
+}

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -1,7 +1,6 @@
 package hetznercloud
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// roundTripFunc lets us mock the HTTP client transport.
 type roundTripFunc func(request *http.Request) *http.Response
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -23,7 +21,7 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 
 // bodyResponse describes a single HTTP response returned by the mock transport.
 type bodyResponse struct {
-	statusCode int
+	statusCode uint
 	body       string
 }
 
@@ -37,7 +35,7 @@ func Test_Provider_waitAction(t *testing.T) {
 	testCases := map[string]struct {
 		id           uint64
 		responses    []bodyResponse
-		wantQueries  int
+		wantQueries  uint
 		errWrapped   error
 		errSubstring string
 	}{
@@ -95,7 +93,7 @@ func Test_Provider_waitAction(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			var queries int
+			var queries uint
 			var lastURL string
 			client := &http.Client{
 				Transport: roundTripFunc(func(request *http.Request) *http.Response {
@@ -103,7 +101,7 @@ func Test_Provider_waitAction(t *testing.T) {
 					response := testCase.responses[queries]
 					queries++
 					return &http.Response{
-						StatusCode: response.statusCode,
+						StatusCode: int(response.statusCode),
 						Body:       io.NopCloser(strings.NewReader(response.body)),
 					}
 				}),
@@ -111,7 +109,7 @@ func Test_Provider_waitAction(t *testing.T) {
 
 			// Use a tiny poll period to keep the test fast.
 			provider := &Provider{token: testToken, actionPollPeriod: time.Millisecond}
-			err := provider.waitAction(context.Background(), client, testCase.id)
+			err := provider.waitAction(t.Context(), client, testCase.id)
 
 			assert.Equal(t, testCase.wantQueries, queries)
 			if testCase.wantQueries > 0 {
@@ -143,7 +141,7 @@ func Test_Provider_waitAction_timeout(t *testing.T) {
 	const actionID = 12345
 	runningBody := fmt.Sprintf(`{"action":{"id":%d,"status":"running"}}`, actionID)
 
-	var queries int
+	var queries uint
 	client := &http.Client{
 		Transport: roundTripFunc(func(_ *http.Request) *http.Response {
 			queries++
@@ -155,11 +153,11 @@ func Test_Provider_waitAction_timeout(t *testing.T) {
 	}
 
 	provider := &Provider{token: testToken, actionPollPeriod: time.Millisecond}
-	err := provider.waitAction(context.Background(), client, actionID)
+	err := provider.waitAction(t.Context(), client, actionID)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errors.ErrUnsuccessful)
 	assert.Contains(t, err.Error(), "did not complete")
 	// The action is polled exactly the maximum number of tries.
-	assert.Equal(t, 12, queries)
+	assert.Equal(t, uint(12), queries)
 }


### PR DESCRIPTION
## What

The `hetznercloud` provider marks successful record updates as failed,
leaving the container permanently unhealthy after an IP change. This fixes two
distinct bugs in the asynchronous action handling.

Fixes #1136

## Background: server actions vs zone actions

The Hetzner Cloud API returns an asynchronous *action* (a background job with
an id and a status) for many operations, and you poll that action until it
reports `success`. Crucially, actions are scoped to the **resource type** they
belong to, and each type has its own lookup path `/{resource}/actions/{id}`:

- `/v1/servers/actions/{id}` — actions for **Cloud Servers** (VPS instances),
  a completely separate Hetzner Cloud product.
- `/v1/zones/actions/{id}` — actions for **DNS zones**, which is what this
  provider works with.

A DNS record update produces a **zone** action, so it must be queried on the
zone path. Querying it on the server path asks the VPS/server subsystem for an
id it has never seen → `404 not_found`.

## Root cause

Record updates via Zone RRSet operations (e.g. `set_records`) return a zone
action that `waitAction` then polls until it reaches `success`. Two things
were wrong:

1. **Wrong endpoint.** It polled the server actions endpoint
   `https://api.hetzner.cloud/v1/servers/actions/{id}` instead of the zone
   actions endpoint `https://api.hetzner.cloud/v1/zones/actions/{id}`, so the
   lookup always returned `404 not_found`. The record itself was already
   updated server-side, but the 404 was treated as an update failure.
   ([waitaction.go#L20](https://github.com/qdm12/ddns-updater/blob/64996182d84adfeb7a873ea32f76b50918f90970/internal/provider/providers/hetznercloud/waitaction.go#L20))

2. **Too short a timeout.** Even against the correct endpoint, zone actions
   take ~20s to reach `success`, but `waitAction` only polled 3 times with a
   1s sleep (~3s total) and then gave up with "did not complete after 3 tries".
   Fixing only the URL would just swap the 404 for a timeout error — the
   container would stay unhealthy.

The action path scheme (`/{resource}/actions/{id}` with `resource = "zones"`)
matches Hetzner's official [hcloud-go](https://github.com/hetznercloud/hcloud-go)
library.

## Fix

- Poll the zone actions endpoint.
- Poll every 5s for up to 60s (12 tries) to accommodate the real action
  duration, while keeping the existing success / error / completion checks.

## Verified against the live Hetzner Cloud API

- Old endpoint `…/v1/servers/actions/{id}` → `404 not_found`; new endpoint
  `…/v1/zones/actions/{id}` → `200` with `"command": "set_rrset_records"` and
  `"resources": [{ "type": "zone" }]`.
- Measured action completion time: ~18–21s (hence the 60s budget).
- The real `ddns-updater` binary, before: `ERROR … 404: not_found`; after:
  the update completes with no error (verified by reading the record back).

## Alternatives considered

1. **Skip the action poll (optimistic update).** As suggested in the issue,
   treat the write as synchronous and consider the update successful as soon
   as `set_records`/`add_records` returns `201`, without waiting for the
   action to reach `success`. The record value is in fact applied server-side
   before the action completes (confirmed by reading it back while the action
   is still `running`). This could be offered as an opt-in provider setting
   (e.g. `"skip_action_check": true`) for users who prefer speed/robustness
   over confirmation. It is not the default here because it gives up genuine
   confirmation that the zone change was accepted.
2. **Treat a 404 on the action lookup as success.** More robust against
   further API quirks, but masks real failures.

This PR keeps the (now working) status check as the default. Happy to add the
opt-in `skip_action_check` option as well if you'd like it in the same PR.

## Open question on the timing values

I went with a fixed 5s interval / 60s total, which comfortably covers the
~20s I measured. Happy to change this if you'd prefer:

- a backoff strategy (e.g. 1s, 2s, 4s … capped) instead of a fixed interval,
- a longer overall budget, or
- making the interval/timeout configurable as optional fields in the provider
  settings (the provider already documents optional params like `ttl` in
  [docs/hetznercloud.md](https://github.com/qdm12/ddns-updater/blob/master/docs/hetznercloud.md)).

Let me know your preference and I'll adjust.

## Tests

`waitaction_test.go` covers the queried URL (the regression), the
`running → success` polling loop, the timeout path, and the success / 404 /
action-error cases. `go test ./...` and `golangci-lint run` pass.