### PR TITLE
feat(provider): `gigahost.no`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This readme and the [docs/](docs/) directory are **versioned** to match the prog
   - FreeDNS
   - Gandi
   - GCP
+  - Gigahost.no
   - GoDaddy
   - GoIP.de
   - He.net
@@ -237,6 +238,7 @@ Check the documentation for your DNS provider:
 - [FreeDNS](docs/freedns.md)
 - [Gandi](docs/gandi.md)
 - [GCP](docs/gcp.md)
+- [Gigahost.no](docs/gigahostno.md)
 - [GoDaddy](docs/godaddy.md)
 - [GoIP.de](docs/goip.md)
 - [He.net](docs/he.net.md)

--- a/docs/gigahostno.md
+++ b/docs/gigahostno.md
@@ -39,8 +39,8 @@
 
 - `"domain"` is the domain to update. It can be `example.no` (root domain), `sub.example.no` (subdomain of `example.no`) or `*.example.no` for the wildcard.
 - Authentication, using **either**:
-    - `"apikey"` is an API key generated from your Gigahost account. This is the recommended method.
-    - `"email"` (your account email) together with `"password"` (your account password).
+  - `"apikey"` is an API key generated from your Gigahost account. This is the recommended method.
+  - `"email"` (your account email) together with `"password"` (your account password).
 
 > ⚠️ Two-factor authentication (2FA) is not supported for now when using `"email"` and `"password"`. If you have 2FA enabled on your account, use an `"apikey"` instead.
 

--- a/docs/gigahostno.md
+++ b/docs/gigahostno.md
@@ -26,7 +26,7 @@
     {
       "provider": "gigahostno",
       "domain": "sub.example.no",
-      "username": "you@example.no",
+      "email": "you@example.no",
       "password": "your password",
       "ip_version": "ipv4",
       "ipv6_suffix": ""
@@ -40,9 +40,9 @@
 - `"domain"` is the domain to update. It can be `example.no` (root domain), `sub.example.no` (subdomain of `example.no`) or `*.example.no` for the wildcard.
 - Authentication, using **either**:
     - `"apikey"` is an API key generated from your Gigahost account. This is the recommended method.
-    - `"username"` (your account email) together with `"password"` (your account password).
+    - `"email"` (your account email) together with `"password"` (your account password).
 
-> ⚠️ Two-factor authentication (2FA) is not supported for now when using `"username"` and `"password"`. If you have 2FA enabled on your account, use an `"apikey"` instead.
+> ⚠️ Two-factor authentication (2FA) is not supported for now when using `"email"` and `"password"`. If you have 2FA enabled on your account, use an `"apikey"` instead.
 
 ### Optional parameters
 
@@ -52,7 +52,7 @@
 ## Domain setup
 
 1. Log in to your [Gigahost account](https://gigahost.no/) and make sure your domain's DNS is hosted at Gigahost.
-2. To use an API key, generate one from your account and set it as `"apikey"`. Otherwise set your account email as `"username"` and your password as `"password"`.
+2. To use an API key, generate one from your account and set it as `"apikey"`. Otherwise set your account email as `"email"` and your password as `"password"`.
 
 The record (`A` for IPv4 and/or `AAAA` for IPv6) is created automatically on the first update if it does not already exist.
 

--- a/docs/gigahostno.md
+++ b/docs/gigahostno.md
@@ -1,0 +1,59 @@
+# Gigahost.no
+
+## Configuration
+
+### Example with an API key
+
+```json
+{
+  "settings": [
+    {
+      "provider": "gigahostno",
+      "domain": "sub.example.no",
+      "apikey": "flux_live_YOUR_API_KEY",
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+### Example with email and password
+
+```json
+{
+  "settings": [
+    {
+      "provider": "gigahostno",
+      "domain": "sub.example.no",
+      "username": "you@example.no",
+      "password": "your password",
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+### Compulsory parameters
+
+- `"domain"` is the domain to update. It can be `example.no` (root domain), `sub.example.no` (subdomain of `example.no`) or `*.example.no` for the wildcard.
+- Authentication, using **either**:
+    - `"apikey"` is an API key generated from your Gigahost account. This is the recommended method.
+    - `"username"` (your account email) together with `"password"` (your account password).
+
+> ⚠️ Two-factor authentication (2FA) is not supported for now when using `"username"` and `"password"`. If you have 2FA enabled on your account, use an `"apikey"` instead.
+
+### Optional parameters
+
+- `"ip_version"` can be `ipv4` (A records), or `ipv6` (AAAA records) or `ipv4 or ipv6` (update one of the two, depending on the public ip found). It defaults to `ipv4 or ipv6`.
+- `"ipv6_suffix"` is the IPv6 interface identifier suffix to use. It can be for example `0:0:0:0:72ad:8fbb:a54e:bedd/64`. If left empty, it defaults to no suffix and the raw temporary IPv6 address of the machine is used in the record updating. You might want to set this to use your permanent IPv6 address instead of your temporary IPv6 address.
+
+## Domain setup
+
+1. Log in to your [Gigahost account](https://gigahost.no/) and make sure your domain's DNS is hosted at Gigahost.
+2. To use an API key, generate one from your account and set it as `"apikey"`. Otherwise set your account email as `"username"` and your password as `"password"`.
+
+The record (`A` for IPv4 and/or `AAAA` for IPv6) is created automatically on the first update if it does not already exist.
+
+More information is available in the [Gigahost API documentation](https://gigahost.no/en/api-dokumentasjon).

--- a/internal/provider/constants/providers.go
+++ b/internal/provider/constants/providers.go
@@ -27,6 +27,7 @@ const (
 	FreeDNS      models.Provider = "freedns"
 	Gandi        models.Provider = "gandi"
 	GCP          models.Provider = "gcp"
+	GigahostNo   models.Provider = "gigahostno"
 	GoDaddy      models.Provider = "godaddy"
 	GoIP         models.Provider = "goip"
 	HE           models.Provider = "he"
@@ -87,6 +88,7 @@ func ProviderChoices() []models.Provider {
 		FreeDNS,
 		Gandi,
 		GCP,
+		GigahostNo,
 		GoDaddy,
 		GoIP,
 		HE,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,6 +33,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/providers/freedns"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/gandi"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/gcp"
+	"github.com/qdm12/ddns-updater/internal/provider/providers/gigahostno"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/godaddy"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/goip"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/he"
@@ -135,6 +136,8 @@ func New(providerName models.Provider, data json.RawMessage, domain, owner strin
 		return gandi.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.GCP:
 		return gcp.New(data, domain, owner, ipVersion, ipv6Suffix)
+	case constants.GigahostNo:
+		return gigahostno.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.GoDaddy:
 		return godaddy.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.GoIP:

--- a/internal/provider/providers/gigahostno/provider.go
+++ b/internal/provider/providers/gigahostno/provider.go
@@ -1,0 +1,202 @@
+package gigahostno
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/headers"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+	"github.com/qdm12/ddns-updater/pkg/ipextract"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+)
+
+type Provider struct {
+	domain     string
+	owner      string
+	ipVersion  ipversion.IPVersion
+	ipv6Suffix netip.Prefix
+	// username is the account email, used with password for HTTP Basic auth.
+	username string
+	password string
+	// apiKey is used as a bearer token instead of username and password.
+	// It is required for accounts with two-factor authentication enabled.
+	apiKey string
+}
+
+func New(data json.RawMessage, domain, owner string,
+	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix) (
+	p *Provider, err error,
+) {
+	extraSettings := struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		APIKey   string `json:"apikey"`
+	}{}
+	err = json.Unmarshal(data, &extraSettings)
+	if err != nil {
+		return nil, fmt.Errorf("json decoding provider specific settings: %w", err)
+	}
+
+	err = validateSettings(domain,
+		extraSettings.Username, extraSettings.Password, extraSettings.APIKey)
+	if err != nil {
+		return nil, fmt.Errorf("validating provider specific settings: %w", err)
+	}
+
+	return &Provider{
+		domain:     domain,
+		owner:      owner,
+		ipVersion:  ipVersion,
+		ipv6Suffix: ipv6Suffix,
+		username:   extraSettings.Username,
+		password:   extraSettings.Password,
+		apiKey:     extraSettings.APIKey,
+	}, nil
+}
+
+func validateSettings(domain, username, password, apiKey string) (err error) {
+	err = utils.CheckDomain(domain)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errors.ErrDomainNotValid, err)
+	}
+
+	// Authentication is done either with an API key or with the
+	// account email and password.
+	if apiKey != "" {
+		return nil
+	}
+
+	switch {
+	case username == "" && password == "":
+		return fmt.Errorf("%w: API key, or username and password, must be set",
+			errors.ErrCredentialsNotSet)
+	case username == "":
+		return fmt.Errorf("%w", errors.ErrUsernameNotSet)
+	case password == "":
+		return fmt.Errorf("%w", errors.ErrPasswordNotSet)
+	}
+	return nil
+}
+
+func (p *Provider) String() string {
+	return utils.ToString(p.domain, p.owner, constants.GigahostNo, p.ipVersion)
+}
+
+func (p *Provider) Domain() string {
+	return p.domain
+}
+
+func (p *Provider) Owner() string {
+	return p.owner
+}
+
+func (p *Provider) IPVersion() ipversion.IPVersion {
+	return p.ipVersion
+}
+
+func (p *Provider) IPv6Suffix() netip.Prefix {
+	return p.ipv6Suffix
+}
+
+func (p *Provider) Proxied() bool {
+	return false
+}
+
+func (p *Provider) BuildDomainName() string {
+	return utils.BuildDomainName(p.owner, p.domain)
+}
+
+func (p *Provider) HTML() models.HTMLRow {
+	return models.HTMLRow{
+		Domain:    fmt.Sprintf("<a href=\"http://%s\">%s</a>", p.BuildDomainName(), p.BuildDomainName()),
+		Owner:     p.Owner(),
+		Provider:  "<a href=\"https://gigahost.no/\">Gigahost</a>",
+		IPVersion: p.ipVersion.String(),
+	}
+}
+
+// Update updates the IP address for the domain using the Gigahost dynamic DNS API.
+// See https://gigahost.no/en/api-dokumentasjon for the API documentation.
+func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Addr) (newIP netip.Addr, err error) {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "api.gigahost.no",
+		Path:   "/api/v0/dns/dyndns",
+	}
+	values := url.Values{}
+	values.Set("hostname", utils.BuildURLQueryHostname(p.owner, p.domain))
+	if ip.Is4() {
+		values.Set("myip", ip.String())
+	} else {
+		values.Set("myipv6", ip.String())
+	}
+	if p.apiKey == "" {
+		// HTTP Basic authentication using the account email and password.
+		u.User = url.UserPassword(p.username, p.password)
+	}
+	u.RawQuery = values.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("creating http request: %w", err)
+	}
+	headers.SetUserAgent(request)
+	if p.apiKey != "" {
+		request.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("doing http request: %w", err)
+	}
+	defer response.Body.Close()
+
+	s, err := utils.ReadAndCleanBody(response.Body)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("reading response: %w", err)
+	}
+
+	switch {
+	case strings.HasPrefix(s, "good"), strings.HasPrefix(s, "nochg"):
+		// success, handled below
+	case response.StatusCode == http.StatusUnauthorized,
+		strings.HasPrefix(s, constants.Badauth):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrAuth)
+	case strings.HasPrefix(s, constants.Nohost), strings.HasPrefix(s, constants.Notfqdn):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrHostnameNotExists)
+	case strings.HasPrefix(s, constants.Badagent):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrIPSentMalformed)
+	case strings.HasPrefix(s, "dnserr"):
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrDNSServerSide)
+	case response.StatusCode != http.StatusOK:
+		return netip.Addr{}, fmt.Errorf("%w: %d: %s",
+			errors.ErrHTTPStatusNotValid, response.StatusCode, utils.ToSingleLine(s))
+	default:
+		return netip.Addr{}, fmt.Errorf("%w: %s", errors.ErrUnknownResponse, utils.ToSingleLine(s))
+	}
+
+	var ips []netip.Addr
+	if ip.Is4() {
+		ips = ipextract.IPv4(s)
+	} else {
+		ips = ipextract.IPv6(s)
+	}
+	if len(ips) == 0 {
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrReceivedNoIP)
+	}
+
+	newIP = ips[0]
+	if newIP.Compare(ip) != 0 {
+		return netip.Addr{}, fmt.Errorf("%w: sent ip %s to update but received %s",
+			errors.ErrIPReceivedMismatch, ip, newIP)
+	}
+	return newIP, nil
+}

--- a/internal/provider/providers/gigahostno/provider.go
+++ b/internal/provider/providers/gigahostno/provider.go
@@ -23,10 +23,10 @@ type Provider struct {
 	owner      string
 	ipVersion  ipversion.IPVersion
 	ipv6Suffix netip.Prefix
-	// username is the account email, used with password for HTTP Basic auth.
-	username string
+	// email is the account email, used with password for HTTP Basic auth.
+	email    string
 	password string
-	// apiKey is used as a bearer token instead of username and password.
+	// apiKey is used as a bearer token instead of email and password.
 	// It is required for accounts with two-factor authentication enabled.
 	apiKey string
 }
@@ -36,7 +36,7 @@ func New(data json.RawMessage, domain, owner string,
 	p *Provider, err error,
 ) {
 	extraSettings := struct {
-		Username string `json:"username"`
+		Email    string `json:"email"`
 		Password string `json:"password"`
 		APIKey   string `json:"apikey"`
 	}{}
@@ -46,7 +46,7 @@ func New(data json.RawMessage, domain, owner string,
 	}
 
 	err = validateSettings(domain,
-		extraSettings.Username, extraSettings.Password, extraSettings.APIKey)
+		extraSettings.Email, extraSettings.Password, extraSettings.APIKey)
 	if err != nil {
 		return nil, fmt.Errorf("validating provider specific settings: %w", err)
 	}
@@ -56,13 +56,13 @@ func New(data json.RawMessage, domain, owner string,
 		owner:      owner,
 		ipVersion:  ipVersion,
 		ipv6Suffix: ipv6Suffix,
-		username:   extraSettings.Username,
+		email:      extraSettings.Email,
 		password:   extraSettings.Password,
 		apiKey:     extraSettings.APIKey,
 	}, nil
 }
 
-func validateSettings(domain, username, password, apiKey string) (err error) {
+func validateSettings(domain, email, password, apiKey string) (err error) {
 	err = utils.CheckDomain(domain)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errors.ErrDomainNotValid, err)
@@ -75,11 +75,11 @@ func validateSettings(domain, username, password, apiKey string) (err error) {
 	}
 
 	switch {
-	case username == "" && password == "":
-		return fmt.Errorf("%w: API key, or username and password, must be set",
+	case email == "" && password == "":
+		return fmt.Errorf("%w: API key, or email and password, must be set",
 			errors.ErrCredentialsNotSet)
-	case username == "":
-		return fmt.Errorf("%w", errors.ErrUsernameNotSet)
+	case email == "":
+		return fmt.Errorf("%w", errors.ErrEmailNotSet)
 	case password == "":
 		return fmt.Errorf("%w", errors.ErrPasswordNotSet)
 	}
@@ -140,7 +140,7 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 	}
 	if p.apiKey == "" {
 		// HTTP Basic authentication using the account email and password.
-		u.User = url.UserPassword(p.username, p.password)
+		u.User = url.UserPassword(p.email, p.password)
 	}
 	u.RawQuery = values.Encode()
 


### PR DESCRIPTION
Adds support for [Gigahost.no](https://gigahost.no/), a Norwegian domain registrar and DNS host.

It uses Gigahost's dynamic DNS API (`GET /api/v0/dns/dyndns`), documented at
https://gigahost.no/en/api-dokumentasjon

Authentication supports either:
- an API key, sent as a bearer token, or
- account email + password, via HTTP Basic auth

Two-factor authentication is not supported with email/password, so accounts with 2FA
enabled should use an API key (noted in the docs). Both IPv4 (`myip`) and IPv6 (`myipv6`)
are supported, and a record is created automatically on the first update if it does not
already exist.

Tested by building the Docker image and running it against a live Gigahost account,
confirming the DNS record is updated.

[Configuration documentation](docs/gigahostno.md)

Fix #1180 
