### PR TITLE
feat(provider): Hetzner Cloud DNS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This readme and the [docs/](docs/) directory are **versioned** to match the prog
   - GoIP.de
   - He.net
   - Hetzner
+  - Hetzner Cloud
   - Infomaniak
   - INWX
   - Ionos
@@ -237,6 +238,7 @@ Check the documentation for your DNS provider:
 - [GoIP.de](docs/goip.md)
 - [He.net](docs/he.net.md)
 - [Hetzner](docs/hetzner.md)
+- [Hetzner Cloud](docs/hetznercloud.md)
 - [Infomaniak](docs/infomaniak.md)
 - [INWX](docs/inwx.md)
 - [Ionos](docs/ionos.md)

--- a/docs/hetznercloud.md
+++ b/docs/hetznercloud.md
@@ -1,0 +1,53 @@
+# Hetzner Cloud
+
+Uses the [Hetzner Cloud API](https://docs.hetzner.cloud/reference/cloud) (`api.hetzner.cloud/v1`) which replaced the legacy Hetzner DNS API (`dns.hetzner.com`) in 2026.
+
+> **Migration note:** If you are currently using `"provider": "hetzner"` (legacy DNS API), migrate to `"provider": "hetznercloud"` before May 2026 when the old API is shut down.
+
+## Configuration
+
+### Example
+
+```json
+{
+  "settings": [
+    {
+      "provider": "hetznercloud",
+      "domain": "domain.com",
+      "token": "yourtoken",
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+With explicit zone ID (optional, saves one API lookup per update):
+
+```json
+{
+  "settings": [
+    {
+      "provider": "hetznercloud",
+      "zone_identifier": "your-zone-id",
+      "domain": "domain.com",
+      "ttl": 3600,
+      "token": "yourtoken",
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+### Compulsory parameters
+
+- `"domain"` is the domain to update. It can be `example.com` (root domain), `sub.example.com` (subdomain of `example.com`) or `*.example.com` for the wildcard.
+- `"token"` is a Hetzner Cloud API token with DNS read and write permissions. [How to generate an API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token)
+
+### Optional parameters
+
+- `"zone_identifier"` is the Zone ID of your DNS zone from the Hetzner Cloud Console. If omitted, it is looked up automatically from `domain`.
+- `"ttl"` is the TTL in seconds for the DNS record. Defaults to `3600`.
+- `"ip_version"` can be `ipv4` (A records), `ipv6` (AAAA records) or `ipv4 or ipv6` (updates whichever public IP is found). Defaults to `ipv4 or ipv6`.
+- `"ipv6_suffix"` is the IPv6 interface identifier suffix to use, for example `0:0:0:0:72ad:8fbb:a54e:bedd/64`. Defaults to no suffix (raw public IPv6 address).

--- a/internal/provider/constants/providers.go
+++ b/internal/provider/constants/providers.go
@@ -31,6 +31,7 @@ const (
 	GoIP         models.Provider = "goip"
 	HE           models.Provider = "he"
 	Hetzner      models.Provider = "hetzner"
+	HetznerCloud models.Provider = "hetznercloud"
 	Infomaniak   models.Provider = "infomaniak"
 	INWX         models.Provider = "inwx"
 	Ionos        models.Provider = "ionos"
@@ -86,6 +87,7 @@ func ProviderChoices() []models.Provider {
 		GoIP,
 		HE,
 		Hetzner,
+		HetznerCloud,
 		Infomaniak,
 		INWX,
 		Ionos,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/providers/goip"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/he"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/hetzner"
+	"github.com/qdm12/ddns-updater/internal/provider/providers/hetznercloud"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/infomaniak"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/inwx"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/ionos"
@@ -138,6 +139,8 @@ func New(providerName models.Provider, data json.RawMessage, domain, owner strin
 		return he.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Hetzner:
 		return hetzner.New(data, domain, owner, ipVersion, ipv6Suffix)
+	case constants.HetznerCloud:
+		return hetznercloud.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Infomaniak:
 		return infomaniak.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.INWX:

--- a/internal/provider/providers/hetznercloud/common.go
+++ b/internal/provider/providers/hetznercloud/common.go
@@ -1,0 +1,14 @@
+package hetznercloud
+
+import (
+	"net/http"
+
+	"github.com/qdm12/ddns-updater/internal/provider/headers"
+)
+
+func (p *Provider) setHeaders(request *http.Request) {
+	headers.SetUserAgent(request)
+	headers.SetContentType(request, "application/json")
+	headers.SetAccept(request, "application/json")
+	request.Header.Set("Authorization", "Bearer "+p.token)
+}

--- a/internal/provider/providers/hetznercloud/getrrset.go
+++ b/internal/provider/providers/hetznercloud/getrrset.go
@@ -1,0 +1,78 @@
+package hetznercloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"net/url"
+
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+)
+
+// getRRSet liefert die aktuelle IP des passenden RRsets (A oder AAAA) zurück.
+// Gibt errors.ErrReceivedNoResult wenn kein passender RRset vorhanden ist.
+// Siehe https://docs.hetzner.cloud/reference/cloud#tag/zones/GET/zones/{zone_id}/rrsets
+func (p *Provider) getRRSet(ctx context.Context, client *http.Client, zoneID string, ip netip.Addr) (
+	currentIP netip.Addr, err error,
+) {
+	recordType := constants.A
+	if ip.Is6() {
+		recordType = constants.AAAA
+	}
+
+	u := url.URL{
+		Scheme: "https",
+		Host:   "api.hetzner.cloud",
+		Path:   "/v1/zones/" + zoneID + "/rrsets",
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("creating http request: %w", err)
+	}
+	p.setHeaders(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return netip.Addr{}, fmt.Errorf("%w: %d: %s",
+			errors.ErrHTTPStatusNotValid, response.StatusCode, utils.BodyToSingleLine(response.Body))
+	}
+
+	var result struct {
+		RRSets []struct {
+			Name    string `json:"name"`
+			Type    string `json:"type"`
+			Records []struct {
+				Value string `json:"value"`
+			} `json:"records"`
+		} `json:"rrsets"`
+	}
+	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return netip.Addr{}, fmt.Errorf("json decoding response body: %w", err)
+	}
+
+	// Passenden RRset nach Name (owner) und Typ filtern
+	for _, rrset := range result.RRSets {
+		if rrset.Name != p.owner || rrset.Type != recordType {
+			continue
+		}
+		if len(rrset.Records) == 0 {
+			return netip.Addr{}, fmt.Errorf("%w", errors.ErrReceivedNoResult)
+		}
+		currentIP, err = netip.ParseAddr(rrset.Records[0].Value)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("%w: %w", errors.ErrIPReceivedMalformed, err)
+		}
+		return currentIP, nil
+	}
+	return netip.Addr{}, fmt.Errorf("%w", errors.ErrReceivedNoResult)
+}

--- a/internal/provider/providers/hetznercloud/getzone.go
+++ b/internal/provider/providers/hetznercloud/getzone.go
@@ -1,0 +1,56 @@
+package hetznercloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+)
+
+// getZoneID ermittelt die Zone-ID anhand des Domain-Namens.
+// Siehe https://docs.hetzner.cloud/reference/cloud#tag/zones/GET/zones
+func (p *Provider) getZoneID(ctx context.Context, client *http.Client) (zoneID string, err error) {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "api.hetzner.cloud",
+		Path:   "/v1/zones",
+	}
+	values := url.Values{}
+	values.Set("name", p.domain)
+	u.RawQuery = values.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("creating http request: %w", err)
+	}
+	p.setHeaders(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: %d: %s",
+			errors.ErrHTTPStatusNotValid, response.StatusCode, utils.BodyToSingleLine(response.Body))
+	}
+
+	var result struct {
+		Zones []struct {
+			ID string `json:"id"`
+		} `json:"zones"`
+	}
+	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("json decoding response body: %w", err)
+	}
+
+	if len(result.Zones) == 0 {
+		return "", fmt.Errorf("%w: %s", errors.ErrZoneNotFound, p.domain)
+	}
+	return result.Zones[0].ID, nil
+}

--- a/internal/provider/providers/hetznercloud/provider.go
+++ b/internal/provider/providers/hetznercloud/provider.go
@@ -1,0 +1,138 @@
+package hetznercloud
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+)
+
+type Provider struct {
+	domain         string
+	owner          string
+	ipVersion      ipversion.IPVersion
+	ipv6Suffix     netip.Prefix
+	token          string
+	zoneIdentifier string // optional: wird per API ermittelt wenn leer
+	ttl            uint32
+}
+
+func New(data json.RawMessage, domain, owner string,
+	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix) (
+	p *Provider, err error,
+) {
+	extraSettings := struct {
+		Token          string `json:"token"`
+		ZoneIdentifier string `json:"zone_identifier"`
+		TTL            uint32 `json:"ttl"`
+	}{}
+	err = json.Unmarshal(data, &extraSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	ttl := uint32(3600)
+	if extraSettings.TTL > 0 {
+		ttl = extraSettings.TTL
+	}
+
+	err = validateSettings(domain, extraSettings.Token)
+	if err != nil {
+		return nil, fmt.Errorf("validating provider specific settings: %w", err)
+	}
+
+	return &Provider{
+		domain:         domain,
+		owner:          owner,
+		ipVersion:      ipVersion,
+		ipv6Suffix:     ipv6Suffix,
+		token:          extraSettings.Token,
+		zoneIdentifier: extraSettings.ZoneIdentifier,
+		ttl:            ttl,
+	}, nil
+}
+
+func validateSettings(domain, token string) (err error) {
+	err = utils.CheckDomain(domain)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errors.ErrDomainNotValid, err)
+	}
+
+	if token == "" {
+		return fmt.Errorf("%w", errors.ErrTokenNotSet)
+	}
+	return nil
+}
+
+func (p *Provider) String() string {
+	return utils.ToString(p.domain, p.owner, constants.HetznerCloud, p.ipVersion)
+}
+
+func (p *Provider) Domain() string {
+	return p.domain
+}
+
+func (p *Provider) Owner() string {
+	return p.owner
+}
+
+func (p *Provider) IPVersion() ipversion.IPVersion {
+	return p.ipVersion
+}
+
+func (p *Provider) IPv6Suffix() netip.Prefix {
+	return p.ipv6Suffix
+}
+
+func (p *Provider) Proxied() bool {
+	return false
+}
+
+func (p *Provider) BuildDomainName() string {
+	return utils.BuildDomainName(p.owner, p.domain)
+}
+
+func (p *Provider) HTML() models.HTMLRow {
+	return models.HTMLRow{
+		Domain:    fmt.Sprintf("<a href=\"http://%s\">%s</a>", p.BuildDomainName(), p.BuildDomainName()),
+		Owner:     p.Owner(),
+		Provider:  "<a href=\"https://www.hetzner.com\">Hetzner Cloud</a>",
+		IPVersion: p.ipVersion.String(),
+	}
+}
+
+func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Addr) (newIP netip.Addr, err error) {
+	// Zone-ID ermitteln (aus Config oder per API-Lookup)
+	zoneID := p.zoneIdentifier
+	if zoneID == "" {
+		zoneID, err = p.getZoneID(ctx, client)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("getting zone id: %w", err)
+		}
+	}
+
+	// Aktuellen RRset prüfen
+	currentIP, err := p.getRRSet(ctx, client, zoneID, ip)
+	switch {
+	case stderrors.Is(err, errors.ErrReceivedNoResult):
+		// Kein RRset vorhanden → neu anlegen via upsert
+	case err != nil:
+		return netip.Addr{}, fmt.Errorf("getting rrset: %w", err)
+	case currentIP.Compare(ip) == 0:
+		return ip, nil // bereits aktuell
+	}
+
+	newIP, err = p.setRRSet(ctx, client, zoneID, ip)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("setting rrset: %w", err)
+	}
+	return newIP, nil
+}

--- a/internal/provider/providers/hetznercloud/provider.go
+++ b/internal/provider/providers/hetznercloud/provider.go
@@ -121,16 +121,24 @@ func (p *Provider) Update(ctx context.Context, client *http.Client, ip netip.Add
 
 	// Aktuellen RRset prüfen
 	currentIP, err := p.getRRSet(ctx, client, zoneID, ip)
+	recordExists := true
 	switch {
 	case stderrors.Is(err, errors.ErrReceivedNoResult):
-		// Kein RRset vorhanden → neu anlegen via upsert
+		recordExists = false // Kein RRset vorhanden → neu anlegen
 	case err != nil:
 		return netip.Addr{}, fmt.Errorf("getting rrset: %w", err)
 	case currentIP.Compare(ip) == 0:
 		return ip, nil // bereits aktuell
 	}
 
-	newIP, err = p.setRRSet(ctx, client, zoneID, ip)
+	// Die Hetzner-Cloud-API trennt Anlegen und Ändern: POST /rrsets legt einen
+	// RRset an (409 Conflict falls er existiert), während die Records eines
+	// bestehenden RRsets über die set_records-Action geändert werden.
+	if recordExists {
+		newIP, err = p.setRecords(ctx, client, zoneID, ip)
+	} else {
+		newIP, err = p.createRRSet(ctx, client, zoneID, ip)
+	}
 	if err != nil {
 		return netip.Addr{}, fmt.Errorf("setting rrset: %w", err)
 	}

--- a/internal/provider/providers/hetznercloud/setrecords.go
+++ b/internal/provider/providers/hetznercloud/setrecords.go
@@ -14,10 +14,12 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/utils"
 )
 
-// createRRSet legt einen neuen RRset an. Existiert der RRset bereits, antwortet
-// die API mit 409 Conflict; bestehende Records werden über setRecords geändert.
-// Siehe https://docs.hetzner.cloud/reference/cloud#tag/zones/POST/zones/{zone_id}/rrsets
-func (p *Provider) createRRSet(ctx context.Context, client *http.Client, zoneID string, ip netip.Addr) (
+// setRecords ändert die Records eines bereits bestehenden RRsets über die
+// set_records-Action. Die Action läuft server-seitig asynchron; wir werten
+// nur den unmittelbaren Status aus und pollen bewusst nicht, da ddns-updater
+// den RRset im nächsten Zyklus ohnehin erneut liest.
+// Siehe https://docs.hetzner.cloud/reference/cloud#tag/zone-actions/POST/zones/{zone_id}/rrsets/{name}/{type}/actions/set_records
+func (p *Provider) setRecords(ctx context.Context, client *http.Client, zoneID string, ip netip.Addr) (
 	newIP netip.Addr, err error,
 ) {
 	recordType := constants.A
@@ -28,20 +30,17 @@ func (p *Provider) createRRSet(ctx context.Context, client *http.Client, zoneID 
 	u := url.URL{
 		Scheme: "https",
 		Host:   "api.hetzner.cloud",
-		Path:   "/v1/zones/" + zoneID + "/rrsets",
+		Path: "/v1/zones/" + zoneID + "/rrsets/" +
+			url.PathEscape(p.owner) + "/" + recordType + "/actions/set_records",
 	}
 
+	// set_records setzt ausschließlich die Records; die TTL wird über die
+	// change_ttl-Action verwaltet und bleibt hier unverändert.
 	requestData := struct {
-		Name    string `json:"name"`
-		Type    string `json:"type"`
-		TTL     uint32 `json:"ttl"`
 		Records []struct {
 			Value string `json:"value"`
 		} `json:"records"`
 	}{
-		Name: p.owner,
-		Type: recordType,
-		TTL:  p.ttl,
 		Records: []struct {
 			Value string `json:"value"`
 		}{{Value: ip.String()}},
@@ -70,28 +69,29 @@ func (p *Provider) createRRSet(ctx context.Context, client *http.Client, zoneID 
 	}
 
 	var result struct {
-		RRSet struct {
-			Records []struct {
-				Value string `json:"value"`
-			} `json:"records"`
-		} `json:"rrset"`
+		Action struct {
+			Status string `json:"status"`
+			Error  *struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"action"`
 	}
 	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
 		return netip.Addr{}, fmt.Errorf("json decoding response body: %w", err)
 	}
 
-	if len(result.RRSet.Records) == 0 {
-		return netip.Addr{}, fmt.Errorf("%w", errors.ErrReceivedNoResult)
+	// Nur ein bereits fehlgeschlagener Action-Status wird als Fehler gewertet;
+	// "running" und "success" gelten als angenommen.
+	if result.Action.Status == "error" {
+		message := "action failed"
+		if result.Action.Error != nil {
+			message = result.Action.Error.Code + ": " + result.Action.Error.Message
+		}
+		return netip.Addr{}, fmt.Errorf("%w: %s", errors.ErrHTTPStatusNotValid, message)
 	}
 
-	newIP, err = netip.ParseAddr(result.RRSet.Records[0].Value)
-	if err != nil {
-		return netip.Addr{}, fmt.Errorf("%w: %w", errors.ErrIPReceivedMalformed, err)
-	}
-
-	if newIP.Compare(ip) != 0 {
-		return netip.Addr{}, fmt.Errorf("%w: sent %s but received %s",
-			errors.ErrIPReceivedMismatch, ip, newIP)
-	}
-	return newIP, nil
+	// Die Action-Antwort enthält keine Records; bei erfolgreicher Annahme wird
+	// die gesendete IP zurückgegeben.
+	return ip, nil
 }

--- a/internal/provider/providers/hetznercloud/setrrset.go
+++ b/internal/provider/providers/hetznercloud/setrrset.go
@@ -1,0 +1,96 @@
+package hetznercloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"net/url"
+
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+)
+
+// setRRSet legt einen RRset an oder aktualisiert ihn (upsert).
+// Siehe https://docs.hetzner.cloud/reference/cloud#tag/zones/POST/zones/{zone_id}/rrsets
+func (p *Provider) setRRSet(ctx context.Context, client *http.Client, zoneID string, ip netip.Addr) (
+	newIP netip.Addr, err error,
+) {
+	recordType := constants.A
+	if ip.Is6() {
+		recordType = constants.AAAA
+	}
+
+	u := url.URL{
+		Scheme: "https",
+		Host:   "api.hetzner.cloud",
+		Path:   "/v1/zones/" + zoneID + "/rrsets",
+	}
+
+	requestData := struct {
+		Name    string `json:"name"`
+		Type    string `json:"type"`
+		TTL     uint32 `json:"ttl"`
+		Records []struct {
+			Value string `json:"value"`
+		} `json:"records"`
+	}{
+		Name:  p.owner,
+		Type:  recordType,
+		TTL:   p.ttl,
+		Records: []struct {
+			Value string `json:"value"`
+		}{{Value: ip.String()}},
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	if err = json.NewEncoder(buffer).Encode(requestData); err != nil {
+		return netip.Addr{}, fmt.Errorf("json encoding request data: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), buffer)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("creating http request: %w", err)
+	}
+	p.setHeaders(request)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
+		return netip.Addr{}, fmt.Errorf("%w: %d: %s",
+			errors.ErrHTTPStatusNotValid, response.StatusCode, utils.BodyToSingleLine(response.Body))
+	}
+
+	var result struct {
+		RRSet struct {
+			Records []struct {
+				Value string `json:"value"`
+			} `json:"records"`
+		} `json:"rrset"`
+	}
+	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return netip.Addr{}, fmt.Errorf("json decoding response body: %w", err)
+	}
+
+	if len(result.RRSet.Records) == 0 {
+		return netip.Addr{}, fmt.Errorf("%w", errors.ErrReceivedNoResult)
+	}
+
+	newIP, err = netip.ParseAddr(result.RRSet.Records[0].Value)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("%w: %w", errors.ErrIPReceivedMalformed, err)
+	}
+
+	if newIP.Compare(ip) != 0 {
+		return netip.Addr{}, fmt.Errorf("%w: sent %s but received %s",
+			errors.ErrIPReceivedMismatch, ip, newIP)
+	}
+	return newIP, nil
+}

--- a/internal/provider/providers/hetznercloud/update_test.go
+++ b/internal/provider/providers/hetznercloud/update_test.go
@@ -1,0 +1,96 @@
+package hetznercloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteTransport leitet alle Anfragen (an api.hetzner.cloud) auf den
+// Test-Server um, ohne den Provider-Code für Tests anpassen zu müssen.
+type rewriteTransport struct {
+	host string
+	base http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.URL.Scheme = "http"
+	request.URL.Host = t.host
+	return t.base.RoundTrip(request)
+}
+
+func Test_Update_routing(t *testing.T) {
+	t.Parallel()
+
+	const zoneID = "zone123"
+	ip := netip.MustParseAddr("2.2.2.2")
+
+	testCases := map[string]struct {
+		rrsetsResponse string // Antwort auf GET .../rrsets
+		wantMethod     string
+		wantPath       string // erwarteter Schreib-Endpoint
+		writeResponse  string
+	}{
+		"existing_record_uses_set_records_action": {
+			rrsetsResponse: `{"rrsets":[{"name":"git","type":"A","records":[{"value":"1.1.1.1"}]}]}`,
+			wantMethod:     http.MethodPost,
+			wantPath:       "/v1/zones/zone123/rrsets/git/A/actions/set_records",
+			writeResponse:  `{"action":{"status":"success"}}`,
+		},
+		"missing_record_creates_rrset": {
+			rrsetsResponse: `{"rrsets":[]}`,
+			wantMethod:     http.MethodPost,
+			wantPath:       "/v1/zones/zone123/rrsets",
+			writeResponse:  `{"rrset":{"records":[{"value":"2.2.2.2"}]}}`,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var writePath, writeMethod string
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/v1/zones/"+zoneID+"/rrsets" {
+					_, _ = io.WriteString(w, testCase.rrsetsResponse)
+					return
+				}
+				// jeder andere Aufruf ist der Schreib-Endpoint
+				writeMethod = r.Method
+				writePath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, testCase.writeResponse)
+			}
+			server := httptest.NewServer(http.HandlerFunc(handler))
+			defer server.Close()
+
+			client := &http.Client{Transport: rewriteTransport{
+				host: strings.TrimPrefix(server.URL, "http://"),
+				base: http.DefaultTransport,
+			}}
+
+			provider := &Provider{
+				domain:         "example.com",
+				owner:          "git",
+				ipVersion:      ipversion.IP4,
+				token:          "token",
+				zoneIdentifier: zoneID,
+				ttl:            3600,
+			}
+
+			newIP, err := provider.Update(context.Background(), client, ip)
+			require.NoError(t, err)
+			assert.Equal(t, ip, newIP)
+			assert.Equal(t, testCase.wantMethod, writeMethod)
+			assert.Equal(t, testCase.wantPath, writePath)
+		})
+	}
+}


### PR DESCRIPTION
## Was

Fügt einen neuen DNS-Provider **Hetzner Cloud** (`hetznercloud`) hinzu, der die neue Zones/RRSets-API unter `api.hetzner.cloud/v1` nutzt (getrennt vom bestehenden Legacy-`hetzner`-Provider gegen `dns.hetzner.com`).

## Wichtiger Fix im Update-Pfad

Die Hetzner-Cloud-API trennt Anlegen und Ändern von RRSets:

- `POST /v1/zones/{zone_id}/rrsets` legt **nur neue** RRSets an und antwortet mit **409 Conflict**, wenn der Record bereits existiert.
- Bestehende Records werden über die Action `POST /v1/zones/{zone_id}/rrsets/{name}/{type}/actions/set_records` geändert.

`Update()` routet nun anhand des vorhandenen RRsets: bestehende Records → `set_records`, neue → `POST /rrsets`. Ohne diese Trennung schlägt jeder Update eines bestehenden Records dauerhaft mit „Failure" fehl.

## Tests

- `go test ./...` grün
- Regressionstest (`update_test.go`) mit `httptest` deckt beide Pfade ab (Create vs. set_records-Action).

## Bekannte Einschränkungen

- Die `set_records`-Action läuft server-seitig asynchron; der Status wird ausgewertet, aber **nicht gepollt** (ddns-updater liest den RRset im nächsten Zyklus erneut).
- Apex-Records (`@`) sind noch nicht gesondert normalisiert (die Cloud-API kann Apex als Zonennamen statt `@` zurückgeben) — für Subdomains getestet.
