### PR TITLE
fix(hetznercloud): poll zone action endpoint instead of server actions

### DIFF
--- a/internal/provider/providers/hetznercloud/waitaction.go
+++ b/internal/provider/providers/hetznercloud/waitaction.go
@@ -18,7 +18,7 @@ func (p *Provider) waitAction(ctx context.Context, client *http.Client, id uint6
 	const sleepDuration = time.Second
 	const tries = 3
 	for range tries {
-		url := fmt.Sprintf("https://api.hetzner.cloud/v1/servers/actions/%d", id)
+		url := fmt.Sprintf("https://api.hetzner.cloud/v1/zones/actions/%d", id)
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return fmt.Errorf("creating http request: %w", err)

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// rewriteTransport leitet alle Anfragen (an api.hetzner.cloud) auf den
-// Test-Server um, ohne den Provider-Code für Tests anpassen zu müssen.
+// rewriteTransport redirects all requests (to api.hetzner.cloud) to the
+// test server, without having to make the provider code test-aware.
 type rewriteTransport struct {
 	host string
 	base http.RoundTripper
@@ -36,9 +36,9 @@ func Test_waitAction(t *testing.T) {
 		wantPath   string
 		wantErr    error
 	}{
-		// Regression: die Action einer set_records-/create-Operation gehört zu
-		// einer Zone, muss also unter /v1/zones/actions/{id} gepollt werden.
-		// Zuvor wurde fälschlich /v1/servers/actions/{id} verwendet (404).
+		// Regression: the action of a set_records/create operation belongs to a
+		// zone, so it must be polled at /v1/zones/actions/{id}.
+		// Previously /v1/servers/actions/{id} was used by mistake, which 404s.
 		"success_polls_zone_action_endpoint": {
 			actionID:   42,
 			statusCode: http.StatusOK,

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -1,0 +1,87 @@
+package hetznercloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteTransport leitet alle Anfragen (an api.hetzner.cloud) auf den
+// Test-Server um, ohne den Provider-Code für Tests anpassen zu müssen.
+type rewriteTransport struct {
+	host string
+	base http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.URL.Scheme = "http"
+	request.URL.Host = t.host
+	return t.base.RoundTrip(request)
+}
+
+func Test_waitAction(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		actionID   uint64
+		statusCode int
+		body       string
+		wantPath   string
+		wantErr    error
+	}{
+		// Regression: die Action einer set_records-/create-Operation gehört zu
+		// einer Zone, muss also unter /v1/zones/actions/{id} gepollt werden.
+		// Zuvor wurde fälschlich /v1/servers/actions/{id} verwendet (404).
+		"success_polls_zone_action_endpoint": {
+			actionID:   42,
+			statusCode: http.StatusOK,
+			body:       `{"action":{"id":42,"status":"success"}}`,
+			wantPath:   "/v1/zones/actions/42",
+		},
+		"error_status_is_reported": {
+			actionID:   43,
+			statusCode: http.StatusOK,
+			body:       `{"action":{"id":43,"status":"error","error":{"code":"failed","message":"boom"}}}`,
+			wantPath:   "/v1/zones/actions/43",
+			wantErr:    errors.ErrUnsuccessful,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotPath string
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(testCase.statusCode)
+				_, _ = io.WriteString(w, testCase.body)
+			}
+			server := httptest.NewServer(http.HandlerFunc(handler))
+			defer server.Close()
+
+			client := &http.Client{Transport: rewriteTransport{
+				host: strings.TrimPrefix(server.URL, "http://"),
+				base: http.DefaultTransport,
+			}}
+
+			provider := &Provider{token: "token"}
+
+			err := provider.waitAction(context.Background(), client, testCase.actionID)
+
+			assert.Equal(t, testCase.wantPath, gotPath)
+			if testCase.wantErr != nil {
+				require.ErrorIs(t, err, testCase.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`waitAction` polls the action returned by `set_records` / `createRRSet` at:

```go
url := fmt.Sprintf("https://api.hetzner.cloud/v1/servers/actions/%d", id)
```

That action belongs to a **zone**, not a **server**. The `servers/actions` collection does not contain the id, so Hetzner responds with `404 not_found` ("action not found"). `handleErrorResponse` turns this into an error, so every update of an **existing** record is reported as `Failure` (and no last-IP is persisted), even though the `set_records`/create action itself succeeds server-side.

Records that never trigger a write (already up to date) are unaffected, which is why the bug only surfaces on the records that actually change IP.

## Fix

Poll the zone-scoped action endpoint instead:

```go
url := fmt.Sprintf("https://api.hetzner.cloud/v1/zones/actions/%d", id)
```

This matches the Hetzner Cloud API pattern `GET /{resource}/actions/{id}` used by the official `hetznercloud/hcloud-go` client (`ResourceActionClient.GetByID` → `"/" + resource + "/actions/%d"`, e.g. `/servers/actions/{id}` for servers, `/zones/actions/{id}` for zones).

## Test

Adds `waitaction_test.go` (httptest) asserting `waitAction` requests `/v1/zones/actions/{id}` and correctly surfaces an `error` action status.

`go test ./...` passes.
