### PR TITLE
fix(hetznercloud): poll zone action endpoint instead of server action

### DIFF
--- a/internal/provider/providers/hetznercloud/waitaction.go
+++ b/internal/provider/providers/hetznercloud/waitaction.go
@@ -18,7 +18,7 @@ func (p *Provider) waitAction(ctx context.Context, client *http.Client, id uint6
 	const sleepDuration = time.Second
 	const tries = 3
 	for range tries {
-		url := fmt.Sprintf("https://api.hetzner.cloud/v1/servers/actions/%d", id)
+		url := fmt.Sprintf("https://api.hetzner.cloud/v1/zones/actions/%d", id)
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return fmt.Errorf("creating http request: %w", err)

--- a/internal/provider/providers/hetznercloud/waitaction_test.go
+++ b/internal/provider/providers/hetznercloud/waitaction_test.go
@@ -1,0 +1,87 @@
+package hetznercloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteTransport redirects all requests (to api.hetzner.cloud) to the
+// test server, without having to make the provider code test-aware.
+type rewriteTransport struct {
+	host string
+	base http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.URL.Scheme = "http"
+	request.URL.Host = t.host
+	return t.base.RoundTrip(request)
+}
+
+func Test_waitAction(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		actionID   uint64
+		statusCode int
+		body       string
+		wantPath   string
+		wantErr    error
+	}{
+		// Regression: the action of a set_records/create operation belongs to a
+		// zone, so it must be polled at /v1/zones/actions/{id}.
+		// Previously /v1/servers/actions/{id} was used by mistake, which 404s.
+		"success_polls_zone_action_endpoint": {
+			actionID:   42,
+			statusCode: http.StatusOK,
+			body:       `{"action":{"id":42,"status":"success"}}`,
+			wantPath:   "/v1/zones/actions/42",
+		},
+		"error_status_is_reported": {
+			actionID:   43,
+			statusCode: http.StatusOK,
+			body:       `{"action":{"id":43,"status":"error","error":{"code":"failed","message":"boom"}}}`,
+			wantPath:   "/v1/zones/actions/43",
+			wantErr:    errors.ErrUnsuccessful,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotPath string
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(testCase.statusCode)
+				_, _ = io.WriteString(w, testCase.body)
+			}
+			server := httptest.NewServer(http.HandlerFunc(handler))
+			defer server.Close()
+
+			client := &http.Client{Transport: rewriteTransport{
+				host: strings.TrimPrefix(server.URL, "http://"),
+				base: http.DefaultTransport,
+			}}
+
+			provider := &Provider{token: "token"}
+
+			err := provider.waitAction(context.Background(), client, testCase.actionID)
+
+			assert.Equal(t, testCase.wantPath, gotPath)
+			if testCase.wantErr != nil {
+				require.ErrorIs(t, err, testCase.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`waitAction` for the `hetznercloud` provider polls the **server** action endpoint for what is a **zone** action:

```go
url := fmt.Sprintf("https://api.hetzner.cloud/v1/servers/actions/%d", id)
```

Record writes (`add_rrset_records`, `set_rrset_records`, …) return an action that lives under `/v1/zones/actions/{id}`. Looking it up under `/v1/servers/actions/{id}` returns `404 not_found`, which `handleErrorResponse` turns into an update failure — even though the record write itself succeeded.

## Why it matters

The DNS record **is** written correctly, but the update is recorded as failed. Consequences reported in #1136:

- `updates.json` is never updated, so the Web UI shows a stale "Current IP" indefinitely
- the healthcheck compares against that stale state, so the container stays `unhealthy`
- reverse proxies that filter on container health drop the Web UI

## Reproduction

Against a live Hetzner Cloud DNS zone, using the same action ID returned by a record write:

```
$ curl -H "Authorization: Bearer $TOKEN" https://api.hetzner.cloud/v1/zones/actions
{"actions":[{"id":<action-id>,"command":"add_rrset_records","status":"success", ...

$ curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
    https://api.hetzner.cloud/v1/zones/actions/<action-id>
200

$ curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
    https://api.hetzner.cloud/v1/servers/actions/<action-id>
404
```

Same ID, both endpoints — only the zone one resolves. On accounts with no cloud servers, `/v1/servers/actions` is empty, so every lookup necessarily 404s.

## Change

One-line fix plus a regression test that asserts the polled path and covers the `error` action status.

Verified on `v2.10.0` (commit 6499618) against a real zone: with the fix, record updates are recorded as successful.

Fixes #1136
