### PR TITLE
fix(ipv6): merge prefix and suffix at sub-byte boundaries

### DIFF
--- a/internal/update/ipv6.go
+++ b/internal/update/ipv6.go
@@ -14,11 +14,19 @@ func ipv6WithSuffix(publicIP netip.Addr, ipv6Suffix netip.Prefix) (
 
 	const ipv6Bits = 128
 	const bitsInByte = 8
-	prefixLength := (ipv6Bits - ipv6Suffix.Bits()) / bitsInByte
+	const byteMask = 0xFF
+	ispBits := ipv6Bits - ipv6Suffix.Bits()
+	prefixLength := ispBits / bitsInByte
+	remainderBits := ispBits % bitsInByte
 	ispPrefix := publicIP.AsSlice()[:prefixLength]
 	localSuffix := ipv6Suffix.Addr().AsSlice()[prefixLength:]
 	ipv6Bytes := ispPrefix // ispPrefix has already 16 bytes of capacity
 	ipv6Bytes = append(ipv6Bytes, localSuffix...)
+	if remainderBits > 0 {
+		pubByte := publicIP.AsSlice()[prefixLength]
+		mask := byte(byteMask << (bitsInByte - remainderBits))
+		ipv6Bytes[prefixLength] = (pubByte & mask) | (ipv6Bytes[prefixLength] & ^mask)
+	}
 	updateIP, ok := netip.AddrFromSlice(ipv6Bytes)
 	if !ok {
 		panic(fmt.Sprintf("failed to create IPv6 address from merged bytes %v", ipv6Bytes))

--- a/internal/update/ipv6_test.go
+++ b/internal/update/ipv6_test.go
@@ -29,10 +29,20 @@ func Test_ipv6WithSuffix(t *testing.T) {
 			ipv6Suffix: netip.MustParsePrefix("0:0:0:0:0:0:0:0/0"),
 			updateIP:   netip.MustParseAddr("e4db:af36:82e:1221:1b7f:2f54:6e9e:5e5f"),
 		},
+		"suffix_68": {
+			publicIP:   netip.MustParseAddr("e4db:af36:82e:1221:1b7f:2f54:6e9e:5e5f"),
+			ipv6Suffix: netip.MustParsePrefix("bbff:8199:4e2f:b4ba:72ad:8fbb:a54e:bedd/68"),
+			updateIP:   netip.MustParseAddr("e4db:af36:82e:122" + "a:72ad:8fbb:a54e:bedd"),
+		},
 		"suffix_64": {
 			publicIP:   netip.MustParseAddr("e4db:af36:82e:1221:1b7f:2f54:6e9e:5e5f"),
 			ipv6Suffix: netip.MustParsePrefix("0:0:0:0:72ad:8fbb:a54e:bedd/64"),
 			updateIP:   netip.MustParseAddr("e4db:af36:82e:1221:" + "72ad:8fbb:a54e:bedd"),
+		},
+		"suffix_60": {
+			publicIP:   netip.MustParseAddr("e4db:af36:82e:1221:1b7f:2f54:6e9e:5e5f"),
+			ipv6Suffix: netip.MustParsePrefix("bbff:8199:4e2f:b4ba:72ad:8fbb:a54e:bedd/60"),
+			updateIP:   netip.MustParseAddr("e4db:af36:82e:1221:1" + "2ad:8fbb:a54e:bedd"),
 		},
 		"suffix_56": {
 			publicIP:   netip.MustParseAddr("e4db:af36:82e:1221:1b7f:2f54:6e9e:5e5f"),


### PR DESCRIPTION
The `ipv6WithSuffix` function now combines the ISP-provided IPv6 prefix from `publicIP` with the user-defined suffix from `ipv6Suffix`. Previously, it assumed that the boundary between the prefix and suffix would always align with full byte boundaries.

This change introduces logic to merge the bits from both the public IP and the IPv6 suffix in the partial byte where the boundary falls, ensuring correct address generation for all valid prefix lengths (e.g., /60, /68).

fix #1188 