### PR TITLE
feat(provider): `rfc2136`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This readme and the [docs/](docs/) directory are **versioned** to match the prog
   - OpenDNS
   - OVH
   - Porkbun
+  - RFC 2136 (BIND, Knot DNS, PowerDNS)
   - Route53
   - Scaleway
   - Selfhost.de
@@ -270,6 +271,7 @@ Check the documentation for your DNS provider:
 - [OpenDNS](docs/opendns.md)
 - [OVH](docs/ovh.md)
 - [Porkbun](docs/porkbun.md)
+- [RFC 2136](docs/rfc2136.md)
 - [Route53](docs/route53.md)
 - [Scaleway](docs/scaleway.md)
 - [Selfhost.de](docs/selfhost.de.md)

--- a/docs/rfc2136.md
+++ b/docs/rfc2136.md
@@ -12,7 +12,6 @@ Updates records on any authoritative name server accepting [RFC 2136](https://da
     {
       "provider": "rfc2136",
       "domain": "domain.com",
-      "owner": "@",
       "server": "ns1.domain.com:53",
       "tsig_key_name": "ddns-key",
       "tsig_secret": "base64encodedsecret==",
@@ -28,7 +27,7 @@ Updates records on any authoritative name server accepting [RFC 2136](https://da
 ### Compulsory parameters
 
 - `"domain"` is the domain to update. It can be `example.com` (root domain) or `sub.example.com` (subdomain of `example.com`).
-- `"server"` is the address of the name server accepting the dynamic updates. The port defaults to `53` if it is not specified. IPv6 addresses must be enclosed in square brackets, for example `[2001:db8::1]:53`.
+- `"server"` is the address of the name server accepting the dynamic updates, port included, for example `ns1.domain.com:53`. IPv6 addresses must be enclosed in square brackets, for example `[2001:db8::1]:53`.
 
 ### Optional parameters
 

--- a/docs/rfc2136.md
+++ b/docs/rfc2136.md
@@ -1,0 +1,70 @@
+# RFC 2136
+
+Updates records on any authoritative name server accepting [RFC 2136](https://datatracker.ietf.org/doc/html/rfc2136) dynamic DNS updates, such as [BIND](https://www.isc.org/bind/), [Knot DNS](https://www.knot-dns.cz/) or [PowerDNS](https://doc.powerdns.com/authoritative/dnsupdate.html). Updates are optionally authenticated with a [TSIG](https://datatracker.ietf.org/doc/html/rfc8945) key.
+
+## Configuration
+
+### Example
+
+```json
+{
+  "settings": [
+    {
+      "provider": "rfc2136",
+      "domain": "domain.com",
+      "owner": "@",
+      "server": "ns1.domain.com:53",
+      "tsig_key_name": "ddns-key",
+      "tsig_secret": "base64encodedsecret==",
+      "tsig_algorithm": "hmac-sha256",
+      "ttl": 300,
+      "ip_version": "ipv4",
+      "ipv6_suffix": ""
+    }
+  ]
+}
+```
+
+### Compulsory parameters
+
+- `"domain"` is the domain to update. It can be `example.com` (root domain) or `sub.example.com` (subdomain of `example.com`).
+- `"server"` is the address of the name server accepting the dynamic updates. The port defaults to `53` if it is not specified. IPv6 addresses must be enclosed in square brackets, for example `[2001:db8::1]:53`.
+
+### Optional parameters
+
+- `"tsig_key_name"` is the name of the TSIG key to sign the update with, as configured on the name server. If it is left unset, the update is sent unsigned, which only works if the name server authorizes the updater by other means, such as an address based ACL.
+- `"tsig_secret"` is the base64 encoded secret of the TSIG key. It is compulsory if `"tsig_key_name"` is set.
+- `"tsig_algorithm"` is the TSIG algorithm to use, and must match the algorithm configured on the name server. It can be `hmac-sha1`, `hmac-sha224`, `hmac-sha256`, `hmac-sha384` or `hmac-sha512`. It defaults to `hmac-sha256`.
+- `"zone"` is the zone to send the update to. It defaults to the `"domain"` value, which is correct in most cases. Set it if the domain to update sits in a zone with a different name, for example when updating `host.sub.example.com` in the `example.com` zone.
+- `"ttl"` is the TTL in seconds of the record to update. It defaults to `300`.
+- `"ip_version"` can be `ipv4` (A records), or `ipv6` (AAAA records) or `ipv4 or ipv6` (update one of the two, depending on the public ip found). It defaults to `ipv4 or ipv6`.
+- `"ipv6_suffix"` is the IPv6 interface identifier suffix to use. It can be for example `0:0:0:0:72ad:8fbb:a54e:bedd/64`. If left empty, it defaults to no suffix and the raw temporary IPv6 address of the machine is used in the record updating. You might want to set this to use your permanent IPv6 address instead of your temporary IPv6 address.
+
+## Domain setup
+
+The steps below are for BIND, but the same concepts apply to other name servers.
+
+1. Generate a TSIG key, for example with `tsig-keygen -a hmac-sha256 ddns-key`, which outputs a block such as:
+
+    ```conf
+    key "ddns-key" {
+        algorithm hmac-sha256;
+        secret "base64encodedsecret==";
+    };
+    ```
+
+1. Add that key block to your BIND configuration.
+1. Allow the key to update your zone:
+
+    ```conf
+    zone "domain.com" {
+        type primary;
+        file "/var/lib/bind/db.domain.com";
+        allow-update { key "ddns-key"; };
+    };
+    ```
+
+1. Reload the configuration with `rndc reload`.
+1. Set `"tsig_key_name"` and `"tsig_secret"` in your configuration to the key name and secret generated above.
+
+Note the updater replaces the entire A or AAAA record set of the domain name with a single record, and creates the record if it does not exist yet. Updates are sent over TCP.

--- a/internal/provider/constants/providers.go
+++ b/internal/provider/constants/providers.go
@@ -53,6 +53,7 @@ const (
 	OpenDNS      models.Provider = "opendns"
 	OVH          models.Provider = "ovh"
 	Porkbun      models.Provider = "porkbun"
+	RFC2136      models.Provider = "rfc2136"
 	Route53      models.Provider = "route53"
 	Scaleway     models.Provider = "scaleway"
 	SelfhostDe   models.Provider = "selfhost.de"
@@ -115,6 +116,7 @@ func ProviderChoices() []models.Provider {
 		OpenDNS,
 		OVH,
 		Porkbun,
+		RFC2136,
 		Route53,
 		Scaleway,
 		SelfhostDe,

--- a/internal/provider/errors/validation.go
+++ b/internal/provider/errors/validation.go
@@ -4,6 +4,7 @@ import "errors"
 
 var (
 	ErrAccessKeyIDNotSet      = errors.New("access key id is not set")
+	ErrAlgorithmNotValid      = errors.New("algorithm is not valid")
 	ErrAccessKeyNotSet        = errors.New("access key is not set")
 	ErrAccessKeySecretNotSet  = errors.New("key secret is not set")
 	ErrAPIKeyNotSet           = errors.New("API key is not set")
@@ -25,6 +26,8 @@ var (
 	ErrPasswordNotValid       = errors.New("password is not valid")
 	ErrSecretKeyNotSet        = errors.New("secret key is not set")
 	ErrSecretNotSet           = errors.New("secret is not set")
+	ErrSecretNotValid         = errors.New("secret is not valid")
+	ErrServerNotSet           = errors.New("server is not set")
 	ErrSuccessRegexNotSet     = errors.New("success regex is not set")
 	ErrTokenNotSet            = errors.New("token is not set")
 	ErrTokenNotValid          = errors.New("token is not valid")

--- a/internal/provider/errors/validation.go
+++ b/internal/provider/errors/validation.go
@@ -28,6 +28,7 @@ var (
 	ErrSecretNotSet           = errors.New("secret is not set")
 	ErrSecretNotValid         = errors.New("secret is not valid")
 	ErrServerNotSet           = errors.New("server is not set")
+	ErrServerNotValid         = errors.New("server is not valid")
 	ErrSuccessRegexNotSet     = errors.New("success regex is not set")
 	ErrTokenNotSet            = errors.New("token is not set")
 	ErrTokenNotValid          = errors.New("token is not valid")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -59,6 +59,7 @@ import (
 	"github.com/qdm12/ddns-updater/internal/provider/providers/opendns"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/ovh"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/porkbun"
+	"github.com/qdm12/ddns-updater/internal/provider/providers/rfc2136"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/route53"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/scaleway"
 	"github.com/qdm12/ddns-updater/internal/provider/providers/selfhostde"
@@ -190,6 +191,8 @@ func New(providerName models.Provider, data json.RawMessage, domain, owner strin
 		return ovh.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Porkbun:
 		return porkbun.New(data, domain, owner, ipVersion, ipv6Suffix)
+	case constants.RFC2136:
+		return rfc2136.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Route53:
 		return route53.New(data, domain, owner, ipVersion, ipv6Suffix)
 	case constants.Scaleway:

--- a/internal/provider/providers/rfc2136/provider.go
+++ b/internal/provider/providers/rfc2136/provider.go
@@ -1,0 +1,242 @@
+package rfc2136
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/internal/provider/utils"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+)
+
+type Provider struct {
+	domain     string
+	owner      string
+	ipVersion  ipversion.IPVersion
+	ipv6Suffix netip.Prefix
+	// server is the address of the name server accepting the
+	// DNS update messages, in the form host:port.
+	server string
+	// zone is the fully qualified zone name to update.
+	zone string
+	// tsigKeyName is the fully qualified TSIG key name. If it is empty,
+	// update messages are sent unsigned.
+	tsigKeyName   string
+	tsigSecret    string
+	tsigAlgorithm string
+	ttl           uint32
+}
+
+func New(data json.RawMessage, domain, owner string,
+	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix) (
+	provider *Provider, err error,
+) {
+	var providerSpecificSettings struct {
+		Server        string `json:"server"`
+		Zone          string `json:"zone"`
+		TSIGKeyName   string `json:"tsig_key_name"`
+		TSIGSecret    string `json:"tsig_secret"`
+		TSIGAlgorithm string `json:"tsig_algorithm"`
+		TTL           uint32 `json:"ttl"`
+	}
+	err = json.Unmarshal(data, &providerSpecificSettings)
+	if err != nil {
+		return nil, fmt.Errorf("json decoding provider specific settings: %w", err)
+	}
+
+	if providerSpecificSettings.Zone == "" {
+		providerSpecificSettings.Zone = domain
+	}
+	if providerSpecificSettings.TSIGAlgorithm == "" {
+		providerSpecificSettings.TSIGAlgorithm = dns.HmacSHA256
+	}
+	if providerSpecificSettings.TTL == 0 {
+		const defaultTTL = 300
+		providerSpecificSettings.TTL = defaultTTL
+	}
+	providerSpecificSettings.TSIGAlgorithm = dns.Fqdn(providerSpecificSettings.TSIGAlgorithm)
+	if providerSpecificSettings.TSIGKeyName != "" {
+		providerSpecificSettings.TSIGKeyName = dns.Fqdn(providerSpecificSettings.TSIGKeyName)
+	}
+
+	err = validateSettings(domain, providerSpecificSettings.Server,
+		providerSpecificSettings.TSIGKeyName, providerSpecificSettings.TSIGSecret,
+		providerSpecificSettings.TSIGAlgorithm)
+	if err != nil {
+		return nil, fmt.Errorf("validating provider specific settings: %w", err)
+	}
+
+	return &Provider{
+		domain:        domain,
+		owner:         owner,
+		ipVersion:     ipVersion,
+		ipv6Suffix:    ipv6Suffix,
+		server:        addressWithDefaultPort(providerSpecificSettings.Server),
+		zone:          dns.Fqdn(providerSpecificSettings.Zone),
+		tsigKeyName:   providerSpecificSettings.TSIGKeyName,
+		tsigSecret:    providerSpecificSettings.TSIGSecret,
+		tsigAlgorithm: providerSpecificSettings.TSIGAlgorithm,
+		ttl:           providerSpecificSettings.TTL,
+	}, nil
+}
+
+// addressWithDefaultPort adds the default DNS port to the server address
+// given, if the address does not already specify a port.
+func addressWithDefaultPort(server string) (address string) {
+	const defaultPort = "53"
+	_, _, err := net.SplitHostPort(server)
+	if err != nil { // no port specified
+		return net.JoinHostPort(server, defaultPort)
+	}
+	return server
+}
+
+func validateSettings(domain, server, tsigKeyName, tsigSecret, tsigAlgorithm string) (err error) {
+	err = utils.CheckDomain(domain)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errors.ErrDomainNotValid, err)
+	}
+
+	switch tsigAlgorithm {
+	case dns.HmacSHA1, dns.HmacSHA224, dns.HmacSHA256, dns.HmacSHA384, dns.HmacSHA512:
+	default:
+		return fmt.Errorf("%w: %s", errors.ErrAlgorithmNotValid, tsigAlgorithm)
+	}
+
+	switch {
+	case server == "":
+		return fmt.Errorf("%w", errors.ErrServerNotSet)
+	case tsigKeyName == "" && tsigSecret != "":
+		return fmt.Errorf("%w", errors.ErrKeyNotSet)
+	case tsigKeyName != "" && tsigSecret == "":
+		return fmt.Errorf("%w", errors.ErrSecretNotSet)
+	}
+
+	if tsigSecret != "" {
+		_, err = base64.StdEncoding.DecodeString(tsigSecret)
+		if err != nil {
+			return fmt.Errorf("%w: %w", errors.ErrSecretNotValid, err)
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) String() string {
+	return utils.ToString(p.domain, p.owner, constants.RFC2136, p.ipVersion)
+}
+
+func (p *Provider) Domain() string {
+	return p.domain
+}
+
+func (p *Provider) Owner() string {
+	return p.owner
+}
+
+func (p *Provider) IPVersion() ipversion.IPVersion {
+	return p.ipVersion
+}
+
+func (p *Provider) IPv6Suffix() netip.Prefix {
+	return p.ipv6Suffix
+}
+
+func (p *Provider) Proxied() bool {
+	return false
+}
+
+func (p *Provider) BuildDomainName() string {
+	return utils.BuildDomainName(p.owner, p.domain)
+}
+
+func (p *Provider) HTML() models.HTMLRow {
+	return models.HTMLRow{
+		Domain:    fmt.Sprintf("<a href=\"http://%s\">%s</a>", p.BuildDomainName(), p.BuildDomainName()),
+		Owner:     p.Owner(),
+		Provider:  "<a href=\"https://datatracker.ietf.org/doc/html/rfc2136\">RFC 2136</a>",
+		IPVersion: p.ipVersion.String(),
+	}
+}
+
+// Update replaces the A or AAAA record set of the domain name with a single
+// record pointing at the IP address given, using a DNS update message as
+// specified in https://datatracker.ietf.org/doc/html/rfc2136.
+// The record is created if it does not exist yet.
+// The HTTP client is unused since the update is sent over DNS.
+func (p *Provider) Update(ctx context.Context, _ *http.Client, ip netip.Addr) (newIP netip.Addr, err error) {
+	message := p.newUpdateMessage(ip)
+
+	// TCP is used instead of UDP to avoid truncated responses, since
+	// updates are infrequent enough for the extra round trips not to matter.
+	client := &dns.Client{Net: "tcp"}
+
+	if p.tsigKeyName != "" {
+		client.TsigSecret = map[string]string{p.tsigKeyName: p.tsigSecret}
+		const fudgeSeconds = 300
+		message.SetTsig(p.tsigKeyName, p.tsigAlgorithm, fudgeSeconds, time.Now().Unix())
+	}
+
+	response, _, err := client.ExchangeContext(ctx, message, p.server)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("exchanging update message with %s: %w", p.server, err)
+	}
+
+	if response.Rcode != dns.RcodeSuccess {
+		return netip.Addr{}, fmt.Errorf("%w: %s", rcodeToError(response.Rcode), dns.RcodeToString[response.Rcode])
+	}
+
+	return ip, nil
+}
+
+// newUpdateMessage builds a DNS update message deleting the existing record
+// set and adding a single record with the IP address given, which the server
+// applies atomically, see https://datatracker.ietf.org/doc/html/rfc2136#section-2.5
+func (p *Provider) newUpdateMessage(ip netip.Addr) (message *dns.Msg) {
+	header := dns.RR_Header{
+		Name:   dns.Fqdn(utils.BuildDomainName(p.owner, p.domain)),
+		Rrtype: dns.TypeA,
+		Class:  dns.ClassINET,
+		Ttl:    p.ttl,
+	}
+
+	var record dns.RR
+	if ip.Is6() {
+		header.Rrtype = dns.TypeAAAA
+		record = &dns.AAAA{Hdr: header, AAAA: net.IP(ip.AsSlice())}
+	} else {
+		record = &dns.A{Hdr: header, A: net.IP(ip.AsSlice())}
+	}
+
+	message = new(dns.Msg)
+	message.SetUpdate(p.zone)
+	message.RemoveRRset([]dns.RR{record})
+	message.Insert([]dns.RR{record})
+	return message
+}
+
+func rcodeToError(rcode int) (err error) {
+	switch rcode {
+	case dns.RcodeNotAuth:
+		return errors.ErrAuth
+	case dns.RcodeRefused:
+		return errors.ErrBadRequest
+	case dns.RcodeNotZone, dns.RcodeNameError:
+		return errors.ErrZoneNotFound
+	case dns.RcodeFormatError:
+		return errors.ErrBadRequest
+	case dns.RcodeServerFailure:
+		return errors.ErrDNSServerSide
+	default:
+		return errors.ErrUnknownResponse
+	}
+}

--- a/internal/provider/providers/rfc2136/provider.go
+++ b/internal/provider/providers/rfc2136/provider.go
@@ -80,24 +80,13 @@ func New(data json.RawMessage, domain, owner string,
 		owner:         owner,
 		ipVersion:     ipVersion,
 		ipv6Suffix:    ipv6Suffix,
-		server:        addressWithDefaultPort(providerSpecificSettings.Server),
+		server:        providerSpecificSettings.Server,
 		zone:          dns.Fqdn(providerSpecificSettings.Zone),
 		tsigKeyName:   providerSpecificSettings.TSIGKeyName,
 		tsigSecret:    providerSpecificSettings.TSIGSecret,
 		tsigAlgorithm: providerSpecificSettings.TSIGAlgorithm,
 		ttl:           providerSpecificSettings.TTL,
 	}, nil
-}
-
-// addressWithDefaultPort adds the default DNS port to the server address
-// given, if the address does not already specify a port.
-func addressWithDefaultPort(server string) (address string) {
-	const defaultPort = "53"
-	_, _, err := net.SplitHostPort(server)
-	if err != nil { // no port specified
-		return net.JoinHostPort(server, defaultPort)
-	}
-	return server
 }
 
 func validateSettings(domain, server, tsigKeyName, tsigSecret, tsigAlgorithm string) (err error) {
@@ -112,9 +101,15 @@ func validateSettings(domain, server, tsigKeyName, tsigSecret, tsigAlgorithm str
 		return fmt.Errorf("%w: %s", errors.ErrAlgorithmNotValid, tsigAlgorithm)
 	}
 
-	switch {
-	case server == "":
+	if server == "" {
 		return fmt.Errorf("%w", errors.ErrServerNotSet)
+	}
+	_, _, err = net.SplitHostPort(server)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errors.ErrServerNotValid, err)
+	}
+
+	switch {
 	case tsigKeyName == "" && tsigSecret != "":
 		return fmt.Errorf("%w", errors.ErrKeyNotSet)
 	case tsigKeyName != "" && tsigSecret == "":
@@ -203,10 +198,9 @@ func (p *Provider) Update(ctx context.Context, _ *http.Client, ip netip.Addr) (n
 // applies atomically, see https://datatracker.ietf.org/doc/html/rfc2136#section-2.5
 func (p *Provider) newUpdateMessage(ip netip.Addr) (message *dns.Msg) {
 	header := dns.RR_Header{
-		Name:   dns.Fqdn(utils.BuildDomainName(p.owner, p.domain)),
-		Rrtype: dns.TypeA,
-		Class:  dns.ClassINET,
-		Ttl:    p.ttl,
+		Name:  dns.Fqdn(utils.BuildDomainName(p.owner, p.domain)),
+		Class: dns.ClassINET,
+		Ttl:   p.ttl,
 	}
 
 	var record dns.RR
@@ -214,6 +208,7 @@ func (p *Provider) newUpdateMessage(ip netip.Addr) (message *dns.Msg) {
 		header.Rrtype = dns.TypeAAAA
 		record = &dns.AAAA{Hdr: header, AAAA: net.IP(ip.AsSlice())}
 	} else {
+		header.Rrtype = dns.TypeA
 		record = &dns.A{Hdr: header, A: net.IP(ip.AsSlice())}
 	}
 
@@ -227,16 +222,16 @@ func (p *Provider) newUpdateMessage(ip netip.Addr) (message *dns.Msg) {
 func rcodeToError(rcode int) (err error) {
 	switch rcode {
 	case dns.RcodeNotAuth:
-		return errors.ErrAuth
+		return fmt.Errorf("%w", errors.ErrAuth)
 	case dns.RcodeRefused:
-		return errors.ErrBadRequest
+		return fmt.Errorf("%w", errors.ErrBadRequest)
 	case dns.RcodeNotZone, dns.RcodeNameError:
-		return errors.ErrZoneNotFound
+		return fmt.Errorf("%w", errors.ErrZoneNotFound)
 	case dns.RcodeFormatError:
-		return errors.ErrBadRequest
+		return fmt.Errorf("%w", errors.ErrBadRequest)
 	case dns.RcodeServerFailure:
-		return errors.ErrDNSServerSide
+		return fmt.Errorf("%w", errors.ErrDNSServerSide)
 	default:
-		return errors.ErrUnknownResponse
+		return fmt.Errorf("%w", errors.ErrUnknownResponse)
 	}
 }

--- a/internal/provider/providers/rfc2136/provider_test.go
+++ b/internal/provider/providers/rfc2136/provider_test.go
@@ -13,57 +13,67 @@ import (
 )
 
 const (
-	exampleZone = "example.com."
-	ipv6Server  = "[2001:db8::1]:5353"
+	exampleZone       = "example.com."
+	testServerAddress = "ns1.example.com:53"
 )
 
 func Test_New(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		data          string
-		expectedErr   error
-		expectedZone  string
-		expectedTTL   uint32
-		expectedSrv   string
-		expectedAlgo  string
-		expectedKeyNm string
+		data             string
+		expectedProvider *Provider
+		expectedErr      error
 	}{
 		"defaults": {
-			data: `{"server":"ns1.example.com"}`,
-			// zone defaults to the domain and the server to port 53.
-			expectedZone: exampleZone,
-			expectedTTL:  300,
-			expectedSrv:  "ns1.example.com:53",
-			expectedAlgo: "hmac-sha256.",
+			data: `{"server":"` + testServerAddress + `"}`,
+			expectedProvider: &Provider{
+				domain:        "example.com",
+				owner:         "home",
+				ipVersion:     ipversion.IP4or6,
+				server:        testServerAddress,
+				zone:          exampleZone,
+				tsigAlgorithm: "hmac-sha256.",
+				ttl:           300,
+			},
 		},
 		"tsig and explicit settings": {
-			data: `{"server":"` + ipv6Server + `","zone":"sub.example.com",` +
+			data: `{"server":"[2001:db8::1]:5353","zone":"sub.example.com",` +
 				`"tsig_key_name":"ddns-key","tsig_secret":"c2VjcmV0","tsig_algorithm":"hmac-sha512","ttl":60}`,
-			expectedZone:  "sub.example.com.",
-			expectedTTL:   60,
-			expectedSrv:   ipv6Server,
-			expectedAlgo:  "hmac-sha512.",
-			expectedKeyNm: "ddns-key.",
+			expectedProvider: &Provider{ //nolint:gosec
+				domain:        "example.com",
+				owner:         "home",
+				ipVersion:     ipversion.IP4or6,
+				server:        "[2001:db8::1]:5353",
+				zone:          "sub.example.com.",
+				tsigKeyName:   "ddns-key.",
+				tsigSecret:    "c2VjcmV0",
+				tsigAlgorithm: "hmac-sha512.",
+				ttl:           60,
+			},
 		},
 		"server not set": {
 			data:        `{}`,
 			expectedErr: errors.ErrServerNotSet,
 		},
+		"server without a port": {
+			data:        `{"server":"ns1.example.com"}`,
+			expectedErr: errors.ErrServerNotValid,
+		},
 		"tsig key without secret": {
-			data:        `{"server":"ns1.example.com","tsig_key_name":"ddns-key"}`,
+			data:        `{"server":"` + testServerAddress + `","tsig_key_name":"ddns-key"}`,
 			expectedErr: errors.ErrSecretNotSet,
 		},
 		"tsig secret without key": {
-			data:        `{"server":"ns1.example.com","tsig_secret":"c2VjcmV0"}`,
+			data:        `{"server":"` + testServerAddress + `","tsig_secret":"c2VjcmV0"}`,
 			expectedErr: errors.ErrKeyNotSet,
 		},
 		"tsig secret not base64": {
-			data:        `{"server":"ns1.example.com","tsig_key_name":"k","tsig_secret":"not base64!"}`,
+			data:        `{"server":"` + testServerAddress + `","tsig_key_name":"k","tsig_secret":"not base64!"}`,
 			expectedErr: errors.ErrSecretNotValid,
 		},
 		"unsupported algorithm": {
-			data:        `{"server":"ns1.example.com","tsig_algorithm":"hmac-md5"}`,
+			data:        `{"server":"` + testServerAddress + `","tsig_algorithm":"hmac-md5"}`,
 			expectedErr: errors.ErrAlgorithmNotValid,
 		},
 	}
@@ -81,11 +91,7 @@ func Test_New(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, testCase.expectedZone, provider.zone)
-			assert.Equal(t, testCase.expectedTTL, provider.ttl)
-			assert.Equal(t, testCase.expectedSrv, provider.server)
-			assert.Equal(t, testCase.expectedAlgo, provider.tsigAlgorithm)
-			assert.Equal(t, testCase.expectedKeyNm, provider.tsigKeyName)
+			assert.Equal(t, testCase.expectedProvider, provider)
 		})
 	}
 }
@@ -147,25 +153,6 @@ func Test_Provider_newUpdateMessage(t *testing.T) {
 			addition := message.Ns[1]
 			assert.Equal(t, uint16(dns.ClassINET), addition.Header().Class)
 			assert.Equal(t, testCase.expectedRecord, addition.String())
-		})
-	}
-}
-
-func Test_addressWithDefaultPort(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]string{
-		"ns1.example.com":      "ns1.example.com:53",
-		"ns1.example.com:5353": "ns1.example.com:5353",
-		"192.168.1.1":          "192.168.1.1:53",
-		"2001:db8::1":          "[2001:db8::1]:53",
-		ipv6Server:             ipv6Server,
-	}
-
-	for server, expected := range testCases {
-		t.Run(server, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, expected, addressWithDefaultPort(server))
 		})
 	}
 }

--- a/internal/provider/providers/rfc2136/provider_test.go
+++ b/internal/provider/providers/rfc2136/provider_test.go
@@ -1,0 +1,171 @@
+package rfc2136
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/qdm12/ddns-updater/internal/provider/errors"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	exampleZone = "example.com."
+	ipv6Server  = "[2001:db8::1]:5353"
+)
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		data          string
+		expectedErr   error
+		expectedZone  string
+		expectedTTL   uint32
+		expectedSrv   string
+		expectedAlgo  string
+		expectedKeyNm string
+	}{
+		"defaults": {
+			data: `{"server":"ns1.example.com"}`,
+			// zone defaults to the domain and the server to port 53.
+			expectedZone: exampleZone,
+			expectedTTL:  300,
+			expectedSrv:  "ns1.example.com:53",
+			expectedAlgo: "hmac-sha256.",
+		},
+		"tsig and explicit settings": {
+			data: `{"server":"` + ipv6Server + `","zone":"sub.example.com",` +
+				`"tsig_key_name":"ddns-key","tsig_secret":"c2VjcmV0","tsig_algorithm":"hmac-sha512","ttl":60}`,
+			expectedZone:  "sub.example.com.",
+			expectedTTL:   60,
+			expectedSrv:   ipv6Server,
+			expectedAlgo:  "hmac-sha512.",
+			expectedKeyNm: "ddns-key.",
+		},
+		"server not set": {
+			data:        `{}`,
+			expectedErr: errors.ErrServerNotSet,
+		},
+		"tsig key without secret": {
+			data:        `{"server":"ns1.example.com","tsig_key_name":"ddns-key"}`,
+			expectedErr: errors.ErrSecretNotSet,
+		},
+		"tsig secret without key": {
+			data:        `{"server":"ns1.example.com","tsig_secret":"c2VjcmV0"}`,
+			expectedErr: errors.ErrKeyNotSet,
+		},
+		"tsig secret not base64": {
+			data:        `{"server":"ns1.example.com","tsig_key_name":"k","tsig_secret":"not base64!"}`,
+			expectedErr: errors.ErrSecretNotValid,
+		},
+		"unsupported algorithm": {
+			data:        `{"server":"ns1.example.com","tsig_algorithm":"hmac-md5"}`,
+			expectedErr: errors.ErrAlgorithmNotValid,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, err := New(json.RawMessage(testCase.data), "example.com", "home",
+				ipversion.IP4or6, netip.Prefix{})
+
+			if testCase.expectedErr != nil {
+				require.ErrorIs(t, err, testCase.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedZone, provider.zone)
+			assert.Equal(t, testCase.expectedTTL, provider.ttl)
+			assert.Equal(t, testCase.expectedSrv, provider.server)
+			assert.Equal(t, testCase.expectedAlgo, provider.tsigAlgorithm)
+			assert.Equal(t, testCase.expectedKeyNm, provider.tsigKeyName)
+		})
+	}
+}
+
+func Test_Provider_newUpdateMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		owner          string
+		ip             netip.Addr
+		expectedName   string
+		expectedType   uint16
+		expectedRecord string
+	}{
+		"ipv4 subdomain": {
+			owner:          "home",
+			ip:             netip.MustParseAddr("1.2.3.4"),
+			expectedName:   "home.example.com.",
+			expectedType:   dns.TypeA,
+			expectedRecord: "home.example.com.\t300\tIN\tA\t1.2.3.4",
+		},
+		"ipv6 root domain": {
+			owner:          "@",
+			ip:             netip.MustParseAddr("2001:db8::1"),
+			expectedName:   "example.com.",
+			expectedType:   dns.TypeAAAA,
+			expectedRecord: "example.com.\t300\tIN\tAAAA\t2001:db8::1",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &Provider{
+				domain: "example.com",
+				owner:  testCase.owner,
+				zone:   exampleZone,
+				ttl:    300,
+			}
+
+			message := provider.newUpdateMessage(testCase.ip)
+
+			// The zone to update is carried in the question section.
+			require.Len(t, message.Question, 1)
+			assert.Equal(t, exampleZone, message.Question[0].Name)
+			assert.Equal(t, dns.TypeSOA, message.Question[0].Qtype)
+			assert.True(t, message.Opcode == dns.OpcodeUpdate)
+
+			// The update section deletes the existing record set before
+			// adding the new record, so the change is applied atomically.
+			require.Len(t, message.Ns, 2)
+
+			deletion := message.Ns[0]
+			assert.Equal(t, testCase.expectedName, deletion.Header().Name)
+			assert.Equal(t, testCase.expectedType, deletion.Header().Rrtype)
+			assert.Equal(t, uint16(dns.ClassANY), deletion.Header().Class)
+
+			addition := message.Ns[1]
+			assert.Equal(t, uint16(dns.ClassINET), addition.Header().Class)
+			assert.Equal(t, testCase.expectedRecord, addition.String())
+		})
+	}
+}
+
+func Test_addressWithDefaultPort(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]string{
+		"ns1.example.com":      "ns1.example.com:53",
+		"ns1.example.com:5353": "ns1.example.com:5353",
+		"192.168.1.1":          "192.168.1.1:53",
+		"2001:db8::1":          "[2001:db8::1]:53",
+		ipv6Server:             ipv6Server,
+	}
+
+	for server, expected := range testCases {
+		t.Run(server, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, expected, addressWithDefaultPort(server))
+		})
+	}
+}


### PR DESCRIPTION

Adds a provider updating records over DNS UPDATE messages ([RFC 2136](https://datatracker.ietf.org/doc/html/rfc2136)), optionally signed with a TSIG key. It works against any authoritative name server accepting dynamic updates, such as BIND, Knot DNS or PowerDNS.

Closes #781
Closes #1155
Closes #325

#325 asks for Dyn's TSIG updates, which is RFC 2136 with the server pinned to `update.dyndns.com`, so a configurable server covers it too.

## One thing worth flagging

This is the first provider that does not use HTTP, so the `*http.Client` passed to `Update` is unused. No interface change was needed, but it is a precedent, so say the word if you would rather it were done differently. `github.com/miekg/dns` was already a direct dependency, so `go.mod` is untouched.

## Design notes

- `zone` is optional and defaults to `domain`, which is right whenever the domain is the zone apex. It can be set for a domain sitting in a differently named zone.
- TSIG is optional. Without a key name the update is sent unsigned, for servers authorizing by address ACL instead.
- The update deletes the record set and adds the new record in a single message, so the server applies it atomically and creates the record if it does not exist yet.
- Updates go over TCP, since they are infrequent and it avoids truncated responses for signed messages.
- Rcodes map onto the existing errors: NOTAUTH to `ErrAuth`, REFUSED to `ErrBadRequest`, NOTZONE/NXDOMAIN to `ErrZoneNotFound`, SERVFAIL to `ErrDNSServerSide`.

## Testing

Build the image with:

```sh
docker build -t qmcgaw/ddns-updater:rfc2136 https://github.com/francisrath/ddns-updater.git#rfc2136
```

And then run with image `qmcgaw/ddns-updater:rfc2136` and a configuration such as:

```json
{
  "settings": [
    {
      "provider": "rfc2136",
      "domain": "example.com",
      "owner": "home",
      "server": "ns1.example.com:53",
      "tsig_key_name": "ddns-key",
      "tsig_secret": "base64secret==",
      "ip_version": "ipv4"
    }
  ]
}
```

[Configuration documentation](https://github.com/francisrath/ddns-updater/blob/rfc2136/docs/rfc2136.md)

Verified against BIND 9.20 in Docker: updating an existing record, creating a missing one, AAAA records, the zone apex, unsigned updates on a permissive zone, and the rejection paths (wrong TSIG secret, unsigned update on a key protected zone, unknown zone). Also ran the updater itself against it end to end.

If it is useful, I kept those tests on a branch stacked on this one, behind an `integration` build tag with a BIND container definition in `testdata`: https://github.com/francisrath/ddns-updater/tree/rfc2136-integration. I left them out of this PR since nothing else in the repo carries test fixtures, but happy to fold them in if you want them.
