### PR TITLE
feat(server): JSON API for record status

### DIFF
--- a/cmd/ddns-updater/main.go
+++ b/cmd/ddns-updater/main.go
@@ -216,7 +216,7 @@ func _main(ctx context.Context, reader *reader.Reader, args []string, logger log
 		return fmt.Errorf("creating health server: %w", err)
 	}
 
-	server, err := createServer(ctx, config.Server, logger, db, updaterService)
+	server, err := createServer(ctx, config.Server, logger, db, updaterService, buildInfo)
 	if err != nil {
 		return fmt.Errorf("creating server: %w", err)
 	}
@@ -369,7 +369,7 @@ func createHealthServer(db health.AllSelecter, resolver health.LookupIPer,
 //nolint:ireturn
 func createServer(ctx context.Context, config config.Server,
 	logger log.LoggerInterface, db server.Database,
-	updaterService server.UpdateForcer) (
+	updaterService server.UpdateForcer, buildInfo models.BuildInformation) (
 	service goservices.Service, err error,
 ) {
 	if !*config.Enabled {
@@ -377,5 +377,5 @@ func createServer(ctx context.Context, config config.Server,
 	}
 	serverLogger := logger.New(log.SetComponent("http server"))
 	return server.New(ctx, config.ListeningAddress, config.RootURL,
-		db, serverLogger, updaterService)
+		db, serverLogger, updaterService, buildInfo)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -85,10 +85,36 @@ type Provider interface {
 	Update(ctx context.Context, client *http.Client, ip netip.Addr) (newIP netip.Addr, err error)
 }
 
+// Namer is implemented by every provider built through [New] and returns the
+// provider name in machine readable form. It is kept separate from [Provider]
+// so the concrete implementations do not each have to declare it.
+type Namer interface {
+	Name() models.Provider
+}
+
+// named decorates a [Provider] with the name it was built from. The concrete
+// implementations only expose their name pre-formatted for HTML, via HTML().
+type named struct {
+	Provider
+	name models.Provider
+}
+
+func (n named) Name() models.Provider { return n.name }
+
 var ErrProviderUnknown = errors.New("unknown provider")
 
-//nolint:gocyclo,maintidx
 func New(providerName models.Provider, data json.RawMessage, domain, owner string, //nolint:ireturn
+	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix,
+) (provider Provider, err error) {
+	provider, err = newProvider(providerName, data, domain, owner, ipVersion, ipv6Suffix)
+	if err != nil {
+		return nil, err
+	}
+	return named{Provider: provider, name: providerName}, nil
+}
+
+//nolint:gocyclo,maintidx
+func newProvider(providerName models.Provider, data json.RawMessage, domain, owner string, //nolint:ireturn
 	ipVersion ipversion.IPVersion, ipv6Suffix netip.Prefix,
 ) (provider Provider, err error) {
 	switch providerName {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/netip"
+	"time"
+
+	"github.com/qdm12/ddns-updater/internal/provider"
+	"github.com/qdm12/ddns-updater/internal/records"
+)
+
+// apiRecord is the machine readable counterpart of [models.HTMLRow].
+// Fields are built explicitly from the provider interface rather than
+// marshaling the provider itself, which carries credentials.
+type apiRecord struct {
+	Domain      string     `json:"domain"`
+	Owner       string     `json:"owner"`
+	FQDN        string     `json:"fqdn"`
+	Provider    string     `json:"provider"`
+	IPVersion   string     `json:"ip_version"`
+	Proxied     bool       `json:"proxied"`
+	Status      string     `json:"status"`
+	Message     string     `json:"message,omitempty"`
+	CurrentIP   string     `json:"current_ip,omitempty"`
+	PreviousIPs []string   `json:"previous_ips"`
+	LastAttempt *time.Time `json:"last_attempt"`
+	LastSuccess *time.Time `json:"last_success"`
+	LastBan     *time.Time `json:"last_ban"`
+}
+
+type apiSummary struct {
+	Total    int            `json:"total"`
+	ByStatus map[string]int `json:"by_status"`
+}
+
+type apiRecordsResponse struct {
+	Records []apiRecord `json:"records"`
+	Summary apiSummary  `json:"summary"`
+}
+
+func (h *handlers) apiRecords(w http.ResponseWriter, _ *http.Request) {
+	all := h.db.SelectAll()
+
+	response := apiRecordsResponse{
+		Records: make([]apiRecord, 0, len(all)),
+		Summary: apiSummary{
+			Total:    len(all),
+			ByStatus: make(map[string]int, len(all)),
+		},
+	}
+
+	for _, record := range all {
+		response.Records = append(response.Records, toAPIRecord(record))
+		response.Summary.ByStatus[string(record.Status)]++
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+func toAPIRecord(record records.Record) apiRecord {
+	providerName := ""
+	if namer, ok := record.Provider.(provider.Namer); ok {
+		providerName = string(namer.Name())
+	}
+
+	previousIPs := record.History.GetPreviousIPs()
+	previousIPsStr := make([]string, 0, len(previousIPs))
+	for _, previousIP := range previousIPs {
+		previousIPsStr = append(previousIPsStr, previousIP.String())
+	}
+
+	return apiRecord{
+		Domain:      record.Provider.Domain(),
+		Owner:       record.Provider.Owner(),
+		FQDN:        record.Provider.BuildDomainName(),
+		Provider:    providerName,
+		IPVersion:   record.Provider.IPVersion().String(),
+		Proxied:     record.Provider.Proxied(),
+		Status:      string(record.Status),
+		Message:     record.Message,
+		CurrentIP:   ipString(record.History.GetCurrentIP()),
+		PreviousIPs: previousIPsStr,
+		LastAttempt: timePtr(record.Time),
+		LastSuccess: timePtr(record.History.GetSuccessTime()),
+		LastBan:     record.LastBan,
+	}
+}
+
+func (h *handlers) apiVersion(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, h.buildInfo)
+}
+
+func ipString(ip netip.Addr) string {
+	if !ip.IsValid() {
+		return ""
+	}
+	return ip.String()
+}
+
+// timePtr returns nil for the zero time so consumers get a JSON null instead
+// of a year 1 timestamp, which would read as a real one.
+func timePtr(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(data)
+	if err != nil {
+		// The status code and possibly part of the body are already written,
+		// so the error can only be logged through the response being truncated.
+		return
+	}
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/qdm12/ddns-updater/internal/constants"
+	"github.com/qdm12/ddns-updater/internal/models"
+	"github.com/qdm12/ddns-updater/internal/provider"
+	providerconstants "github.com/qdm12/ddns-updater/internal/provider/constants"
+	"github.com/qdm12/ddns-updater/internal/provider/providers/cloudflare"
+	"github.com/qdm12/ddns-updater/internal/records"
+	"github.com/qdm12/ddns-updater/pkg/publicip/ipversion"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDatabase struct {
+	records []records.Record
+}
+
+func (f fakeDatabase) SelectAll() []records.Record { return f.records }
+
+type fakeRunner struct{}
+
+func (fakeRunner) ForceUpdate(_ context.Context) []error { return nil }
+
+//nolint:ireturn
+func newTestProvider(t *testing.T) provider.Provider {
+	t.Helper()
+	settings := []byte(`{"token":"secret-token","zone_identifier":"secret-zone","proxied":true,"ttl":600}`)
+	p, err := provider.New(providerconstants.Cloudflare, settings, "example.com", "www",
+		ipversion.IP4, netip.Prefix{})
+	require.NoError(t, err)
+	return p
+}
+
+func testHandler(t *testing.T, recordsList []records.Record) http.Handler {
+	t.Helper()
+	return newHandler(context.Background(), "", fakeDatabase{records: recordsList},
+		fakeRunner{}, models.BuildInformation{Version: "v1.2.3", Commit: "abcdef1", Created: "2026-01-01"})
+}
+
+func Test_apiRecords(t *testing.T) {
+	t.Parallel()
+
+	lastAttempt := time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC)
+	lastSuccess := time.Date(2026, 8, 12, 22, 13, 7, 0, time.UTC)
+
+	record := records.New(newTestProvider(t), []models.HistoryEvent{
+		{IP: netip.MustParseAddr("203.0.113.1"), Time: lastSuccess.Add(-time.Hour)},
+		{IP: netip.MustParseAddr("203.0.113.2"), Time: lastSuccess.Add(-time.Minute)},
+		{IP: netip.MustParseAddr("203.0.113.4"), Time: lastSuccess},
+	})
+	record.Status = constants.UPTODATE
+	record.Time = lastAttempt
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/records", nil)
+	testHandler(t, []records.Record{record}).ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+
+	var response apiRecordsResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+
+	require.Len(t, response.Records, 1)
+	got := response.Records[0]
+
+	assert.Equal(t, "example.com", got.Domain)
+	assert.Equal(t, "www", got.Owner)
+	assert.Equal(t, "www.example.com", got.FQDN)
+	assert.Equal(t, "cloudflare", got.Provider)
+	assert.Equal(t, "ipv4", got.IPVersion)
+	assert.True(t, got.Proxied)
+	assert.Equal(t, "up to date", got.Status)
+	assert.Equal(t, "203.0.113.4", got.CurrentIP)
+
+	// Full history, unlike the HTML view which truncates to two.
+	assert.Equal(t, []string{"203.0.113.2", "203.0.113.1"}, got.PreviousIPs)
+
+	require.NotNil(t, got.LastAttempt)
+	assert.Equal(t, lastAttempt, got.LastAttempt.UTC())
+	require.NotNil(t, got.LastSuccess)
+	assert.Equal(t, lastSuccess, got.LastSuccess.UTC())
+	assert.Nil(t, got.LastBan)
+
+	assert.Equal(t, 1, response.Summary.Total)
+	assert.Equal(t, map[string]int{"up to date": 1}, response.Summary.ByStatus)
+}
+
+// Test_apiRecords_noCredentials is the important one: provider settings carry
+// secrets, so the response must never contain them.
+func Test_apiRecords_noCredentials(t *testing.T) {
+	t.Parallel()
+
+	record := records.New(newTestProvider(t), nil)
+	record.Status = constants.SUCCESS
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/records", nil)
+	testHandler(t, []records.Record{record}).ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	body := recorder.Body.String()
+	assert.NotContains(t, body, "secret-token")
+	assert.NotContains(t, body, "secret-zone")
+}
+
+func Test_apiRecords_emptyDatabase(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/records", nil)
+	testHandler(t, nil).ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"records":[],"summary":{"total":0,"by_status":{}}}`, recorder.Body.String())
+}
+
+// Test_apiRecords_unsetRecord covers a record which has never updated, where
+// the IP and both timestamps are zero values.
+func Test_apiRecords_unsetRecord(t *testing.T) {
+	t.Parallel()
+
+	record := records.New(newTestProvider(t), nil)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/records", nil)
+	testHandler(t, []records.Record{record}).ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var response apiRecordsResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Len(t, response.Records, 1)
+	got := response.Records[0]
+
+	assert.Equal(t, "unset", got.Status)
+	assert.Empty(t, got.CurrentIP)
+	assert.Empty(t, got.PreviousIPs)
+	assert.Nil(t, got.LastAttempt)
+	assert.Nil(t, got.LastSuccess)
+}
+
+func Test_apiVersion(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/version", nil)
+	testHandler(t, nil).ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"version":"v1.2.3","commit":"abcdef1","buildDate":"2026-01-01"}`,
+		recorder.Body.String())
+}
+
+// Test_apiRecords_rootURL checks the endpoints honor the configured root URL,
+// the same way the index and update routes do.
+func Test_apiRecords_rootURL(t *testing.T) {
+	t.Parallel()
+
+	handler := newHandler(context.Background(), "/ddns", fakeDatabase{}, fakeRunner{},
+		models.BuildInformation{})
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ddns/api/v1/records", nil))
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/records", nil))
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+// Test_providerName covers the decorator added in provider.New, since the
+// concrete providers only expose their name pre-formatted for HTML.
+func Test_providerName(t *testing.T) {
+	t.Parallel()
+
+	p := newTestProvider(t)
+	namer, ok := p.(provider.Namer)
+	require.True(t, ok, "provider built through provider.New must implement Namer")
+	assert.Equal(t, providerconstants.Cloudflare, namer.Name())
+
+	// The concrete type on its own does not, which is why the decorator exists.
+	var concrete any = &cloudflare.Provider{}
+	_, ok = concrete.(provider.Namer)
+	assert.False(t, ok)
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/qdm12/ddns-updater/internal/models"
 )
 
 type handlers struct {
@@ -19,6 +20,7 @@ type handlers struct {
 	db            Database
 	runner        UpdateForcer
 	indexTemplate *template.Template
+	buildInfo     models.BuildInformation
 	// Mockable functions
 	timeNow func() time.Time
 }
@@ -27,7 +29,7 @@ type handlers struct {
 var uiFS embed.FS
 
 func newHandler(ctx context.Context, rootURL string,
-	db Database, runner UpdateForcer,
+	db Database, runner UpdateForcer, buildInfo models.BuildInformation,
 ) http.Handler {
 	indexTemplate := template.Must(template.ParseFS(uiFS, "ui/index.html"))
 
@@ -40,9 +42,9 @@ func newHandler(ctx context.Context, rootURL string,
 		ctx:           ctx,
 		db:            db,
 		indexTemplate: indexTemplate,
-		// TODO build information
-		timeNow: time.Now,
-		runner:  runner,
+		buildInfo:     buildInfo,
+		timeNow:       time.Now,
+		runner:        runner,
 	}
 
 	router := chi.NewRouter()
@@ -57,6 +59,9 @@ func newHandler(ctx context.Context, rootURL string,
 	router.Get(rootURL+"/", handlers.index)
 
 	router.Get(rootURL+"/update", handlers.update)
+
+	router.Get(rootURL+"/api/v1/records", handlers.apiRecords)
+	router.Get(rootURL+"/api/v1/version", handlers.apiVersion)
 
 	router.Handle(rootURL+"/static/*", http.StripPrefix(rootURL+"/static/", http.FileServerFS(staticFolder)))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,14 +3,15 @@ package server
 import (
 	"context"
 
+	"github.com/qdm12/ddns-updater/internal/models"
 	"github.com/qdm12/goservices/httpserver"
 )
 
 func New(ctx context.Context, address, rootURL string, db Database,
-	logger Logger, runner UpdateForcer,
+	logger Logger, runner UpdateForcer, buildInfo models.BuildInformation,
 ) (server *httpserver.Server, err error) {
 	return httpserver.New(httpserver.Settings{
-		Handler: newHandler(ctx, rootURL, db, runner),
+		Handler: newHandler(ctx, rootURL, db, runner, buildInfo),
 		Address: &address,
 		Logger:  logger,
 	})


### PR DESCRIPTION
Closes #987

Adds a read-only JSON API so dashboards and monitoring tools can read record status without scraping the HTML table. Follows up on my comment in #987, where I offered this as a demo before opening a PR.

Endpoints
`GET /api/v1/records` returns the same rows the index page renders, unformatted:

```json
{
  "records": [
    {
      "domain": "example.com",
      "owner": "www",
      "fqdn": "www.example.com",
      "provider": "cloudflare",
      "ip_version": "ipv4",
      "proxied": true,
      "status": "up to date",
      "current_ip": "203.0.113.4",
      "previous_ips": ["203.0.113.2", "203.0.113.1"],
      "last_attempt": "2026-08-14T09:00:00Z",
      "last_success": "2026-08-12T22:13:07Z",
      "last_ban": null
    }
  ],
  "summary": {
    "total": 1,
    "by_status": { "up to date": 1 }
  }
}
```

`GET /api/v1/version` returns build information, which fills in the // TODO build information in newHandler.

Both respect ROOT_URL, the same way / and /update do.

### Implementation
No changes to any of the provider packages. Provider already exposes Domain(), Owner(), BuildDomainName(), IPVersion() and Proxied() as plain accessors. Only HTML() bakes in markup, and this does not touch it.
The handler builds an explicit DTO from db.SelectAll() rather than marshaling records directly.
Read-only throughout. No changes to update logic, and no new dependencies.

_Three things I would like your call on_

- Provider name. There is no plain accessor today (String() is composite, HTML() is marked up) and the name is lost once provider.New returns the interface. I renamed the existing switch to newProvider and had New wrap the result in a decorator carrying the name, exposed through a separate Namer interface. That is ~25 lines in provider.go alone, nothing added to Provider, and no provider package touched. If you would rather thread the name through params and store it on Record, or add Name() to Provider properly, I will switch.

- message. It carries raw provider response text, and on failure that can be large. Running the example provider produces a message holding an entire HTML error page, several hundred bytes for one record. It is already exposed that way in the UI so it is not new information, but as a JSON field it is noisy. Happy to truncate it, drop it, or leave it at parity with the UI.

- The version endpoint. See the note on exposure below. It is deliberately on its own route so it can be dropped or gated independently of the records endpoint.

### On exposure
Credentials cannot leak by accident: every provider's key / token / password / email field is unexported, so encoding/json cannot reach them, and the handler marshals an explicit DTO rather than the provider struct. There is a test that seeds a Cloudflare provider with a fake token and zone identifier and asserts neither appears in the response.

Most of this is already served ungated by /, but not all of it. **Newly reachable over HTTP**:

proxied and last_ban, which are not in the web UI at all
previous IPs past the first two, since the HTML view prints 2 then and N more, so the count is already public but those addresses are not
build version and commit, which today only go to stdout at startup
Everything else is already on the index page, including message and the timestamps, the latter as relative strings.

I left authentication out of scope, since gating the API while the UI serves nearly the same table ungated does not buy much, and most people run this behind a reverse proxy. The original post in #987 suggested an API key, so say the word if you would rather have one.

### Related issues, not closed by this
#751 asks to view more previous IPs in the web interface, ideally with per-IP dates. This makes the full list retrievable over the API, but does not change the UI and does not include per-IP timestamps, so it only partially addresses it.
#1194 is the duplicate-history bug I reported separately. It is more visible here because previous_ips is not truncated, but the fix belongs in the update path, not in this PR.

### Testing
New tests cover the happy path, an empty database, a record that has never updated, ROOT_URL handling, the version endpoint, the provider-name decorator, and the credential-leak assertion.
Run against a live instance to confirm the index page and /update still behave, and the endpoint verified against a real multi-record configuration.